### PR TITLE
Update CoreDNS from v1.2.6 to v1.3.0

### DIFF
--- a/resources/manifests/coredns/config.yaml
+++ b/resources/manifests/coredns/config.yaml
@@ -8,7 +8,9 @@ data:
     .:53 {
         errors
         health
-        log
+        log . {
+            class error
+        }
         kubernetes ${cluster_domain_suffix} ${service_cidr} {
             pods insecure
             upstream

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "container_images" {
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.2.3"
     hyperkube        = "k8s.gcr.io/hyperkube:v1.13.1"
-    coredns          = "k8s.gcr.io/coredns:1.2.6"
+    coredns          = "k8s.gcr.io/coredns:1.3.0"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }
 }


### PR DESCRIPTION
* https://coredns.io/2018/12/15/coredns-1.3.0-release/
* Limit log plugin to just log error class