### PR TITLE
Switch CoreDNS to use the forward plugin instead of proxy

### DIFF
--- a/resources/manifests/coredns/config.yaml
+++ b/resources/manifests/coredns/config.yaml
@@ -17,7 +17,7 @@ data:
             fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
         cache 30
         loop
         reload


### PR DESCRIPTION
* Use the forward plugin to forward to upstream resolvers, instead of the proxy plugin. The forward plugin is reported to be a faster alternative since it can re-use open sockets
* https://coredns.io/explugins/forward/
* https://coredns.io/plugins/proxy/
* https://github.com/kubernetes/kubernetes/issues/73254