### PR TITLE
Rename project to terraform-render-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# terraform-render-bootkube
+# terraform-render-bootstrap
 
-`terraform-render-bootkube` is a Terraform module that renders TLS certificates, static pods, and manifests for bootstrapping a Kubernetes cluster.
+`terraform-render-bootstrap` is a Terraform module that renders TLS certificates, static pods, and manifests for bootstrapping a Kubernetes cluster.
 
 ## Audience
 
@@ -12,7 +12,7 @@ Use the module to declare bootstrap assets. Check [variables.tf](variables.tf) f
 
 ```hcl
 module "bootstrap" {
-  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=SHA"
+  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=SHA"
 
   cluster_name = "example"
   api_servers = ["node1.example.com"]

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -11,7 +11,7 @@ resource "tls_self_signed_cert" "kube-ca" {
 
   subject {
     common_name  = "kubernetes-ca"
-    organization = "bootkube"
+    organization = "typhoon"
   }
 
   is_ca_certificate     = true


### PR DESCRIPTION
* Rename from terraform-render-bootkube to terraform-render-bootstrap
* Generated manifest and certificate assets are no longer geared specifically for bootkube (no longer used)
* Rename the organization in generated CA certificates for clusters from bootkube to typhoon
* Mainly helpful to avoid confusion with bootkube CA certificates if users inspect their CA, especially now that bootkube isn't used (better their searches lead to Typhoon)