### PR TITLE
Switch kube-proxy from iptables mode to ipvs mode

### DIFF
--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -40,7 +40,7 @@ spec:
         - --cluster-cidr=${pod_cidr}
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --proxy-mode=iptables
+        - --proxy-mode=ipvs
         env:
           - name: NODE_NAME
             valueFrom:


### PR DESCRIPTION
* Kubernetes v1.11 considered kube-proxy IPVS mode GA
* Many problems were found https://github.com/poseidon/typhoon/pull/321
* Since then, major blockers seem to have been addressed