### PR TITLE
Use for_each + templatefile instead of template_dir

### DIFF
--- a/conditional.tf
+++ b/conditional.tf
@@ -1,23 +1,21 @@
 # Assets generated only when certain options are chosen
 
-resource "template_dir" "flannel-manifests" {
-  count           = var.networking == "flannel" ? 1 : 0
-  source_dir      = "${path.module}/resources/flannel"
-  destination_dir = "${var.asset_dir}/manifests-networking"
+resource "local_file" "flannel-manifests" {
+  for_each = var.networking == "flannel" ? fileset("${path.module}/resources/flannel", "**/*.yaml") : []
 
-  vars = {
+  filename = "${var.asset_dir}/manifests-networking/${each.value}"
+  content = templatefile("${path.module}/resources/flannel/${each.value}", {
     flannel_image     = var.container_images["flannel"]
     flannel_cni_image = var.container_images["flannel_cni"]
     pod_cidr          = var.pod_cidr
-  }
+  })
 }
 
-resource "template_dir" "calico-manifests" {
-  count           = var.networking == "calico" ? 1 : 0
-  source_dir      = "${path.module}/resources/calico"
-  destination_dir = "${var.asset_dir}/manifests-networking"
+resource "local_file" "calico-manifests" {
+  for_each = var.networking == "calico" ? fileset("${path.module}/resources/calico", "**/*.yaml") : []
 
-  vars = {
+  filename = "${var.asset_dir}/manifests-networking/${each.value}"
+  content = templatefile("${path.module}/resources/calico/${each.value}", {
     calico_image                    = var.container_images["calico"]
     calico_cni_image                = var.container_images["calico_cni"]
     network_mtu                     = var.network_mtu
@@ -28,18 +26,17 @@ resource "template_dir" "calico-manifests" {
     network_ip_autodetection_method = var.network_ip_autodetection_method
     pod_cidr                        = var.pod_cidr
     enable_reporting                = var.enable_reporting
-  }
+  })
 }
 
-resource "template_dir" "kube-router-manifests" {
-  count           = var.networking == "kube-router" ? 1 : 0
-  source_dir      = "${path.module}/resources/kube-router"
-  destination_dir = "${var.asset_dir}/manifests-networking"
+resource "local_file" "kube-router-manifests" {
+  for_each = var.networking == "kube-router" ? fileset("${path.module}/resources/kube-router", "**/*.yaml") : []
 
-  vars = {
+  filename = "${var.asset_dir}/manifests-networking/${each.value}"
+  content = templatefile("${path.module}/resources/kube-router/${each.value}", {
     kube_router_image = var.container_images["kube_router"]
     flannel_cni_image = var.container_images["flannel_cni"]
     network_mtu       = var.network_mtu
-  }
+  })
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,16 @@
+locals {
+  combined-static-manifest-contents = [for manifest in local_file.static-manifests : "${manifest.filename}${manifest.content}"]
+  combined-manifest-contents        = [for manifest in local_file.manifests : "${manifest.filename}${manifest.content}"]
+  static-manifests-hash             = sha1(join("", local.combined-static-manifest-contents))
+  manifests-hash                    = sha1(join("", local.combined-manifest-contents))
+}
+
 output "id" {
-  value = sha1("${template_dir.static-manifests.id} ${template_dir.manifests.id}")
+  value = sha1("${local.static-manifests-hash} ${local.manifests-hash}")
 }
 
 output "content_hash" {
-  value = sha1("${template_dir.static-manifests.id} ${template_dir.manifests.id}")
+  value = sha1("${local.static-manifests-hash} ${local.manifests-hash}")
 }
 
 output "cluster_dns_service_ip" {


### PR DESCRIPTION
To avoid template provider issue on windows: https://github.com/terraform-providers/terraform-provider-template/issues/73

Even though this PR still uses local_file resource, the change would also make it easier to change resource type to `aws_s3_bucket_object` by patching the content of the module.
I'd like to customize the module for putting all generated files to s3 instead of local filesystem.
Changing all `local_file` to `aws_s3_bucket_object` still requires some work when new files are added to the module, but better than nothing.

I suppose it's also possible to output only content of generated manifests. That way, users of the module could put content to remote store like S3 if they want.
Let's start with this PR anyway, so that we could avoid making BC-breaking changes to the module.

`template_dir` resource type doesn't support outputting to s3 and probably never will. Since the name of generated files is not included in the plan, it's not possible to consume generated files either without writing hand-written scripts.