### PR TITLE
Adopt Terraform v0.12 templatefile function

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -1,46 +1,26 @@
-# Kubernetes static pod manifests
-resource "template_dir" "static-manifests" {
-  source_dir      = "${path.module}/resources/static-manifests"
-  destination_dir = "${var.asset_dir}/static-manifests"
+# Generated kubeconfig for Kubelets
+data "template_file" "kubeconfig-kubelet" {
+  template = file("${path.module}/resources/kubeconfig-kubelet")
 
   vars = {
-    hyperkube_image   = var.container_images["hyperkube"]
-    etcd_servers      = join(",", formatlist("https://%s:2379", var.etcd_servers))
-    cloud_provider    = var.cloud_provider
-    pod_cidr          = var.pod_cidr
-    service_cidr      = var.service_cidr
-    trusted_certs_dir = var.trusted_certs_dir
-    aggregation_flags = var.enable_aggregation ? indent(4, local.aggregation_flags) : ""
+    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    kubelet_cert = base64encode(tls_locally_signed_cert.kubelet.cert_pem)
+    kubelet_key  = base64encode(tls_private_key.kubelet.private_key_pem)
+    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
   }
 }
 
-# Kubernetes control plane manifests
-resource "template_dir" "manifests" {
-  source_dir      = "${path.module}/resources/manifests"
-  destination_dir = "${var.asset_dir}/manifests"
+# Generated admin kubeconfig to bootstrap control plane
+data "template_file" "kubeconfig-admin" {
+  template = file("${path.module}/resources/kubeconfig-admin")
 
   vars = {
-    hyperkube_image        = var.container_images["hyperkube"]
-    coredns_image          = var.container_images["coredns"]
-    control_plane_replicas = max(2, length(var.etcd_servers))
-    pod_cidr               = var.pod_cidr
-    cluster_domain_suffix  = var.cluster_domain_suffix
-    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
-    trusted_certs_dir      = var.trusted_certs_dir
-    server                 = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
+    name         = var.cluster_name
+    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    kubelet_cert = base64encode(tls_locally_signed_cert.admin.cert_pem)
+    kubelet_key  = base64encode(tls_private_key.admin.private_key_pem)
+    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
   }
-}
-
-locals {
-  aggregation_flags = <<EOF
-
-- --proxy-client-cert-file=/etc/kubernetes/secrets/aggregation-client.crt
-- --proxy-client-key-file=/etc/kubernetes/secrets/aggregation-client.key
-- --requestheader-client-ca-file=/etc/kubernetes/secrets/aggregation-ca.crt
-- --requestheader-extra-headers-prefix=X-Remote-Extra-
-- --requestheader-group-headers=X-Remote-Group
-- --requestheader-username-headers=X-Remote-User
-EOF
 }
 
 # Generated kubeconfig for Kubelets
@@ -60,27 +40,3 @@ resource "local_file" "kubeconfig-admin-named" {
   content  = data.template_file.kubeconfig-admin.rendered
   filename = "${var.asset_dir}/auth/${var.cluster_name}-config"
 }
-
-data "template_file" "kubeconfig-kubelet" {
-  template = file("${path.module}/resources/kubeconfig-kubelet")
-
-  vars = {
-    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
-    kubelet_cert = base64encode(tls_locally_signed_cert.kubelet.cert_pem)
-    kubelet_key  = base64encode(tls_private_key.kubelet.private_key_pem)
-    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
-  }
-}
-
-data "template_file" "kubeconfig-admin" {
-  template = file("${path.module}/resources/kubeconfig-admin")
-
-  vars = {
-    name         = var.cluster_name
-    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
-    kubelet_cert = base64encode(tls_locally_signed_cert.admin.cert_pem)
-    kubelet_key  = base64encode(tls_private_key.admin.private_key_pem)
-    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
-  }
-}
-

--- a/conditional.tf
+++ b/conditional.tf
@@ -1,45 +1,76 @@
 # Assets generated only when certain options are chosen
 
-resource "template_dir" "flannel-manifests" {
-  count           = var.networking == "flannel" ? 1 : 0
-  source_dir      = "${path.module}/resources/flannel"
-  destination_dir = "${var.asset_dir}/manifests-networking"
+locals {
+  # flannel manifests (manifest.yaml => content)
+  flannel_manifests = {
+    for name in fileset("${path.module}/resources/flannel", "*.yaml"):
+    "manifests-networking/${name}" => templatefile(
+      "${path.module}/resources/flannel/${name}",
+      {
+        flannel_image     = var.container_images["flannel"]
+        flannel_cni_image = var.container_images["flannel_cni"]
+        pod_cidr          = var.pod_cidr
+      }
+    )
+    if var.networking == "flannel"
+  }
 
-  vars = {
-    flannel_image     = var.container_images["flannel"]
-    flannel_cni_image = var.container_images["flannel_cni"]
-    pod_cidr          = var.pod_cidr
+  # calico manifests (manifest.yaml => content)
+  calico_manifests = {
+    for name in fileset("${path.module}/resources/calico", "*.yaml"):
+    "manifests-networking/${name}" => templatefile(
+      "${path.module}/resources/calico/${name}",
+      {
+        calico_image                    = var.container_images["calico"]
+        calico_cni_image                = var.container_images["calico_cni"]
+        network_mtu                     = var.network_mtu
+        network_encapsulation           = indent(2, var.network_encapsulation == "vxlan" ? "vxlanMode: Always" : "ipipMode: Always")
+        ipip_enabled                    = var.network_encapsulation == "ipip" ? true : false
+        ipip_readiness                  = var.network_encapsulation == "ipip" ? indent(16, "- --bird-ready") : ""
+        vxlan_enabled                   = var.network_encapsulation == "vxlan" ? true : false
+        network_ip_autodetection_method = var.network_ip_autodetection_method
+        pod_cidr                        = var.pod_cidr
+        enable_reporting                = var.enable_reporting
+      }
+    )
+    if var.networking == "calico"
+  }
+
+  # kube-router manifests (manifest.yaml => content)
+  kube_router_manifests = {
+    for name in fileset("${path.module}/resources/kube-router", "*.yaml"):
+    "manifests-networking/${name}" => templatefile(
+      "${path.module}/resources/kube-router/${name}",
+      {
+        kube_router_image = var.container_images["kube_router"]
+        flannel_cni_image = var.container_images["flannel_cni"]
+        network_mtu       = var.network_mtu
+      }
+    )
+    if var.networking == "kube-router"
   }
 }
 
-resource "template_dir" "calico-manifests" {
-  count           = var.networking == "calico" ? 1 : 0
-  source_dir      = "${path.module}/resources/calico"
-  destination_dir = "${var.asset_dir}/manifests-networking"
+# flannel manifests
+resource "local_file" "flannel-manifests" {
+  for_each = local.flannel_manifests
 
-  vars = {
-    calico_image                    = var.container_images["calico"]
-    calico_cni_image                = var.container_images["calico_cni"]
-    network_mtu                     = var.network_mtu
-    network_encapsulation           = indent(2, var.network_encapsulation == "vxlan" ? "vxlanMode: Always" : "ipipMode: Always")
-    ipip_enabled                    = var.network_encapsulation == "ipip" ? true : false
-    ipip_readiness                  = var.network_encapsulation == "ipip" ? indent(16, "- --bird-ready") : ""
-    vxlan_enabled                   = var.network_encapsulation == "vxlan" ? true : false
-    network_ip_autodetection_method = var.network_ip_autodetection_method
-    pod_cidr                        = var.pod_cidr
-    enable_reporting                = var.enable_reporting
-  }
+  filename = "${var.asset_dir}/${each.key}"
+  content  = each.value
 }
 
-resource "template_dir" "kube-router-manifests" {
-  count           = var.networking == "kube-router" ? 1 : 0
-  source_dir      = "${path.module}/resources/kube-router"
-  destination_dir = "${var.asset_dir}/manifests-networking"
+# Calico manifests
+resource "local_file" "calico-manifests" {
+  for_each = local.calico_manifests
 
-  vars = {
-    kube_router_image = var.container_images["kube_router"]
-    flannel_cni_image = var.container_images["flannel_cni"]
-    network_mtu       = var.network_mtu
-  }
+  filename = "${var.asset_dir}/${each.key}"
+  content  = each.value
 }
 
+# kube-router manifests
+resource "local_file" "kube-router-manifests" {
+  for_each = local.kube_router_manifests
+
+  filename = "${var.asset_dir}/${each.key}"
+  content  = each.value
+}

--- a/manifests.tf
+++ b/manifests.tf
@@ -1,0 +1,65 @@
+locals {
+  # Kubernetes static pod manifests (manifest.yaml => content)
+  static_manifests = {
+    for name in fileset("${path.module}/resources/static-manifests", "*.yaml"):
+    "static-manifests/${name}" => templatefile(
+      "${path.module}/resources/static-manifests/${name}",
+      {
+        hyperkube_image   = var.container_images["hyperkube"]
+        etcd_servers      = join(",", formatlist("https://%s:2379", var.etcd_servers))
+        cloud_provider    = var.cloud_provider
+        pod_cidr          = var.pod_cidr
+        service_cidr      = var.service_cidr
+        trusted_certs_dir = var.trusted_certs_dir
+        aggregation_flags = var.enable_aggregation ? indent(4, local.aggregation_flags) : ""
+      }
+    )
+  }
+
+  # Kubernetes control plane manifests (manifest.yaml => content)
+  manifests = {
+    for name in fileset("${path.module}/resources/manifests", "**/*.yaml"):
+    "manifests/${name}" => templatefile(
+      "${path.module}/resources/manifests/${name}",
+      {
+        hyperkube_image        = var.container_images["hyperkube"]
+        coredns_image          = var.container_images["coredns"]
+        control_plane_replicas = max(2, length(var.etcd_servers))
+        pod_cidr               = var.pod_cidr
+        cluster_domain_suffix  = var.cluster_domain_suffix
+        cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+        trusted_certs_dir      = var.trusted_certs_dir
+        server                 = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
+      }
+    )
+  }
+}
+
+# Kubernetes static pod manifests
+resource "local_file" "static-manifests" {
+  for_each = local.static_manifests
+
+  content  = each.value
+  filename = "${var.asset_dir}/${each.key}"
+}
+
+# Kubernetes control plane manifests
+resource "local_file" "manifests" {
+  for_each = local.manifests
+
+  content  = each.value
+  filename = "${var.asset_dir}/${each.key}"
+}
+
+locals {
+  aggregation_flags = <<EOF
+
+- --proxy-client-cert-file=/etc/kubernetes/secrets/aggregation-client.crt
+- --proxy-client-key-file=/etc/kubernetes/secrets/aggregation-client.key
+- --requestheader-client-ca-file=/etc/kubernetes/secrets/aggregation-ca.crt
+- --requestheader-extra-headers-prefix=X-Remote-Extra-
+- --requestheader-group-headers=X-Remote-Group
+- --requestheader-username-headers=X-Remote-User
+EOF
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,3 @@
-output "id" {
-  value = sha1("${template_dir.static-manifests.id} ${template_dir.manifests.id}")
-}
-
-output "content_hash" {
-  value = sha1("${template_dir.static-manifests.id} ${template_dir.manifests.id}")
-}
 
 output "cluster_dns_service_ip" {
   value = cidrhost(var.service_cidr, 10)


### PR DESCRIPTION
* Adopt Terrform v0.12 type and templatefile function features to replace the use of terraform-provider-template's `template_dir`
* Use of `for_each` to write local assets requires that consumers use Terraform v0.12.6+ (action required)
* Continue use of `template_file` as its quite common. In future, we may replace it as well.
* Remove outputs `id` and `content_hash` (no longer used)

Background:

* `template_dir` was added to `terraform-provider-template` to add support for template directory rendering in CoreOS Tectonic Kubernetes distribution (~2017)
* Terraform v0.12 introduced a native `templatefile` function and v0.12.6 introduced native `for_each` support (July 2019) that makes it possible to replace `template_dir` usage