### PR TITLE
Update CoreDNS from v1.6.2 to v1.6.5

### DIFF
--- a/resources/manifests/coredns/config.yaml
+++ b/resources/manifests/coredns/config.yaml
@@ -7,7 +7,9 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health {
+          lameduck 5s
+        }
         ready
         log . {
             class error

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "container_images" {
     flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router = "cloudnativelabs/kube-router:v0.3.2"
     hyperkube   = "k8s.gcr.io/hyperkube:v1.16.3"
-    coredns     = "k8s.gcr.io/coredns:1.6.2"
+    coredns     = "k8s.gcr.io/coredns:1.6.5"
   }
 }
 


### PR DESCRIPTION
* Add health `lameduck` option 5s. Before CoreDNS shuts down, it will wait and report unhealthy for 5s to allow time for plugins to shutdown cleanly
* Minor bug fixes over a few releases
* https://coredns.io/2019/08/31/coredns-1.6.3-release/
* https://coredns.io/2019/09/27/coredns-1.6.4-release/
* https://coredns.io/2019/11/05/coredns-1.6.5-release/