### PR TITLE
Add small CPU resource requests to static pods

### DIFF
--- a/resources/static-manifests/kube-apiserver.yaml
+++ b/resources/static-manifests/kube-apiserver.yaml
@@ -44,6 +44,9 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    resources:
+      requests:
+        cpu: 200m
     volumeMounts:
     - name: secrets
       mountPath: /etc/kubernetes/secrets

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -39,6 +39,9 @@ spec:
         port: 10257
       initialDelaySeconds: 15
       timeoutSeconds: 15
+    resources:
+      requests:
+        cpu: 200m
     volumeMounts:
     - name: secrets
       mountPath: /etc/kubernetes/secrets

--- a/resources/static-manifests/kube-scheduler.yaml
+++ b/resources/static-manifests/kube-scheduler.yaml
@@ -30,6 +30,9 @@ spec:
         port: 10259
       initialDelaySeconds: 15
       timeoutSeconds: 15
+    resources:
+      requests:
+        cpu: 100m
     volumeMounts:
     - name: secrets
       mountPath: /etc/kubernetes/secrets


### PR DESCRIPTION
* Set small CPU requests on static pods kube-apiserver,
kube-controller-manager, and kube-scheduler to align with
upstream tooling and for edge cases
* Control plane nodes are tainted to isolate them from
ordinary workloads. Even dense workloads can only compress
CPU resources on worker nodes.
* Control plane static pods use the highest priority class, so
contention favors control plane pods (over say node-exporter)
and CPU is compressible too.
* Effectively, a practical case for these requests hasn't been
observed. However, a small static pod CPU request may offer
a slight benefit if a controller became overloaded and the
above mechanisms were insufficient for some reason (bit of a
stretch, due to CPU compressibility)
* Continue to avoid setting a memory request for static pods.
It would impose a hard size requirement on controller nodes,
which isn't warranted and is handled more gently by Typhoon
default instance types across clouds and via docs