### PR TITLE
Introduce a Terraform output map with distribution assets

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -1,3 +1,10 @@
+locals {
+  # auth kubeconfig assets map
+  auth_kubeconfigs = {
+    "auth/kubeconfig" = data.template_file.kubeconfig-admin.rendered,
+  }
+}
+
 # Generated kubeconfig for Kubelets
 data "template_file" "kubeconfig-kubelet" {
   template = file("${path.module}/resources/kubeconfig-kubelet")

--- a/conditional.tf
+++ b/conditional.tf
@@ -1,7 +1,8 @@
 # Assets generated only when certain options are chosen
 
 locals {
-  # flannel manifests (manifest.yaml => content)
+  # flannel manifests map
+  # { manifests-networking/manifest.yaml => content }
   flannel_manifests = {
     for name in fileset("${path.module}/resources/flannel", "*.yaml"):
     "manifests-networking/${name}" => templatefile(
@@ -15,7 +16,8 @@ locals {
     if var.networking == "flannel"
   }
 
-  # calico manifests (manifest.yaml => content)
+  # calico manifests map
+  # { manifests-networking/manifest.yaml => content }
   calico_manifests = {
     for name in fileset("${path.module}/resources/calico", "*.yaml"):
     "manifests-networking/${name}" => templatefile(
@@ -36,7 +38,8 @@ locals {
     if var.networking == "calico"
   }
 
-  # kube-router manifests (manifest.yaml => content)
+  # kube-router manifests map
+  # { manifests-networking/manifest.yaml => content }
   kube_router_manifests = {
     for name in fileset("${path.module}/resources/kube-router", "*.yaml"):
     "manifests-networking/${name}" => templatefile(

--- a/manifests.tf
+++ b/manifests.tf
@@ -1,5 +1,6 @@
 locals {
-  # Kubernetes static pod manifests (manifest.yaml => content)
+  # Kubernetes static pod manifests map
+  # {static-manifests/manifest.yaml => content }
   static_manifests = {
     for name in fileset("${path.module}/resources/static-manifests", "*.yaml"):
     "static-manifests/${name}" => templatefile(
@@ -16,7 +17,8 @@ locals {
     )
   }
 
-  # Kubernetes control plane manifests (manifest.yaml => content)
+  # Kubernetes control plane manifests map
+  # { manifests/manifest.yaml => content }
   manifests = {
     for name in fileset("${path.module}/resources/manifests", "**/*.yaml"):
     "manifests/${name}" => templatefile(

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,23 @@ output "kubeconfig-admin" {
   value = data.template_file.kubeconfig-admin.rendered
 }
 
+# assets to distribute to controllers
+# { some/path => content }
+output "assets_dist" {
+  # combine maps of assets
+  value = merge(
+    local.auth_kubeconfigs,
+    local.etcd_tls,
+    local.kubernetes_tls,
+    local.aggregation_tls,
+    local.static_manifests,
+    local.manifests,
+    local.flannel_manifests,
+    local.calico_manifests,
+    local.kube_router_manifests,
+  )
+}
+
 # etcd TLS assets
 
 output "etcd_ca_cert" {

--- a/tls-aggregation.tf
+++ b/tls-aggregation.tf
@@ -1,3 +1,14 @@
+locals {
+  # Kubernetes Aggregation TLS assets map
+  aggregation_tls = var.enable_aggregation ? {
+    "tls/k8s/aggregation-ca.crt" = tls_self_signed_cert.aggregation-ca[0].cert_pem,
+    "tls/k8s/aggregation-client.crt" = tls_locally_signed_cert.aggregation-client[0].cert_pem,
+    "tls/k8s/aggregation-client.key" = tls_private_key.aggregation-client[0].private_key_pem,
+  } : {}
+}
+
+
+
 # Kubernetes Aggregation CA (i.e. front-proxy-ca)
 # Files: tls/{aggregation-ca.crt,aggregation-ca.key}
 

--- a/tls-etcd.tf
+++ b/tls-etcd.tf
@@ -1,70 +1,19 @@
-# etcd-ca.crt
-resource "local_file" "etcd_ca_crt" {
-  content  = tls_self_signed_cert.etcd-ca.cert_pem
-  filename = "${var.asset_dir}/tls/etcd-ca.crt"
+locals {
+  # etcd TLS assets map
+  etcd_tls = {
+    "tls/etcd/etcd-client-ca.crt" = tls_self_signed_cert.etcd-ca.cert_pem,
+    "tls/etcd/etcd-client.crt" = tls_locally_signed_cert.client.cert_pem,
+    "tls/etcd/etcd-client.key" = tls_private_key.client.private_key_pem
+    "tls/etcd/server-ca.crt" = tls_self_signed_cert.etcd-ca.cert_pem,
+    "tls/etcd/server.crt" = tls_locally_signed_cert.server.cert_pem
+    "tls/etcd/server.key" = tls_private_key.server.private_key_pem
+    "tls/etcd/peer-ca.crt" = tls_self_signed_cert.etcd-ca.cert_pem,
+    "tls/etcd/peer.crt" = tls_locally_signed_cert.peer.cert_pem
+    "tls/etcd/peer.key" = tls_private_key.peer.private_key_pem
+  }
 }
 
-# etcd-ca.key
-resource "local_file" "etcd_ca_key" {
-  content  = tls_private_key.etcd-ca.private_key_pem
-  filename = "${var.asset_dir}/tls/etcd-ca.key"
-}
-
-# etcd-client-ca.crt
-resource "local_file" "etcd_client_ca_crt" {
-  content  = tls_self_signed_cert.etcd-ca.cert_pem
-  filename = "${var.asset_dir}/tls/etcd-client-ca.crt"
-}
-
-# etcd-client.crt
-resource "local_file" "etcd_client_crt" {
-  content  = tls_locally_signed_cert.client.cert_pem
-  filename = "${var.asset_dir}/tls/etcd-client.crt"
-}
-
-# etcd-client.key
-resource "local_file" "etcd_client_key" {
-  content  = tls_private_key.client.private_key_pem
-  filename = "${var.asset_dir}/tls/etcd-client.key"
-}
-
-# server-ca.crt
-resource "local_file" "etcd_server_ca_crt" {
-  content  = tls_self_signed_cert.etcd-ca.cert_pem
-  filename = "${var.asset_dir}/tls/etcd/server-ca.crt"
-}
-
-# server.crt
-resource "local_file" "etcd_server_crt" {
-  content  = tls_locally_signed_cert.server.cert_pem
-  filename = "${var.asset_dir}/tls/etcd/server.crt"
-}
-
-# server.key
-resource "local_file" "etcd_server_key" {
-  content  = tls_private_key.server.private_key_pem
-  filename = "${var.asset_dir}/tls/etcd/server.key"
-}
-
-# peer-ca.crt
-resource "local_file" "etcd_peer_ca_crt" {
-  content  = tls_self_signed_cert.etcd-ca.cert_pem
-  filename = "${var.asset_dir}/tls/etcd/peer-ca.crt"
-}
-
-# peer.crt
-resource "local_file" "etcd_peer_crt" {
-  content  = tls_locally_signed_cert.peer.cert_pem
-  filename = "${var.asset_dir}/tls/etcd/peer.crt"
-}
-
-# peer.key
-resource "local_file" "etcd_peer_key" {
-  content  = tls_private_key.peer.private_key_pem
-  filename = "${var.asset_dir}/tls/etcd/peer.key"
-}
-
-# certificates and keys
+# etcd CA
 
 resource "tls_private_key" "etcd-ca" {
   algorithm = "RSA"
@@ -90,8 +39,26 @@ resource "tls_self_signed_cert" "etcd-ca" {
   ]
 }
 
-# client certs are used for client (apiserver, locksmith, etcd-operator)
-# to etcd communication
+# etcd-ca.crt
+resource "local_file" "etcd_ca_crt" {
+  content  = tls_self_signed_cert.etcd-ca.cert_pem
+  filename = "${var.asset_dir}/tls/etcd-ca.crt"
+}
+
+# etcd-client-ca.crt
+resource "local_file" "etcd_client_ca_crt" {
+  content  = tls_self_signed_cert.etcd-ca.cert_pem
+  filename = "${var.asset_dir}/tls/etcd-client-ca.crt"
+}
+
+# etcd-ca.key
+resource "local_file" "etcd_ca_key" {
+  content  = tls_private_key.etcd-ca.private_key_pem
+  filename = "${var.asset_dir}/tls/etcd-ca.key"
+}
+
+# etcd Client (apiserver to etcd communication)
+
 resource "tls_private_key" "client" {
   algorithm = "RSA"
   rsa_bits  = "2048"
@@ -129,6 +96,20 @@ resource "tls_locally_signed_cert" "client" {
     "client_auth",
   ]
 }
+
+# etcd-client.crt
+resource "local_file" "etcd_client_crt" {
+  content  = tls_locally_signed_cert.client.cert_pem
+  filename = "${var.asset_dir}/tls/etcd-client.crt"
+}
+
+# etcd-client.key
+resource "local_file" "etcd_client_key" {
+  content  = tls_private_key.client.private_key_pem
+  filename = "${var.asset_dir}/tls/etcd-client.key"
+}
+
+# etcd Server
 
 resource "tls_private_key" "server" {
   algorithm = "RSA"
@@ -168,6 +149,26 @@ resource "tls_locally_signed_cert" "server" {
   ]
 }
 
+# server-ca.crt
+resource "local_file" "etcd_server_ca_crt" {
+  content  = tls_self_signed_cert.etcd-ca.cert_pem
+  filename = "${var.asset_dir}/tls/etcd/server-ca.crt"
+}
+
+# server.crt
+resource "local_file" "etcd_server_crt" {
+  content  = tls_locally_signed_cert.server.cert_pem
+  filename = "${var.asset_dir}/tls/etcd/server.crt"
+}
+
+# server.key
+resource "local_file" "etcd_server_key" {
+  content  = tls_private_key.server.private_key_pem
+  filename = "${var.asset_dir}/tls/etcd/server.key"
+}
+
+# etcd Peer
+
 resource "tls_private_key" "peer" {
   algorithm = "RSA"
   rsa_bits  = "2048"
@@ -200,5 +201,23 @@ resource "tls_locally_signed_cert" "peer" {
     "server_auth",
     "client_auth",
   ]
+}
+
+# peer-ca.crt
+resource "local_file" "etcd_peer_ca_crt" {
+  content  = tls_self_signed_cert.etcd-ca.cert_pem
+  filename = "${var.asset_dir}/tls/etcd/peer-ca.crt"
+}
+
+# peer.crt
+resource "local_file" "etcd_peer_crt" {
+  content  = tls_locally_signed_cert.peer.cert_pem
+  filename = "${var.asset_dir}/tls/etcd/peer.crt"
+}
+
+# peer.key
+resource "local_file" "etcd_peer_key" {
+  content  = tls_private_key.peer.private_key_pem
+  filename = "${var.asset_dir}/tls/etcd/peer.key"
 }
 

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -1,3 +1,15 @@
+locals {
+  # Kubernetes TLS assets map
+  kubernetes_tls = {
+    "tls/k8s/ca.crt" = tls_self_signed_cert.kube-ca.cert_pem,
+    "tls/k8s/ca.key" = tls_private_key.kube-ca.private_key_pem,
+    "tls/k8s/apiserver.crt" = tls_locally_signed_cert.apiserver.cert_pem,
+    "tls/k8s/apiserver.key" = tls_private_key.apiserver.private_key_pem,
+    "tls/k8s/service-account.pub" = tls_private_key.service-account.public_key_pem
+    "tls/k8s/service-account.key" = tls_private_key.service-account.private_key_pem
+  }
+}
+
 # Kubernetes CA (tls/{ca.crt,ca.key})
 
 resource "tls_private_key" "kube-ca" {


### PR DESCRIPTION
* Introduce a new `assets_dist` output variable that provides a mapping from suggested asset paths to asset contents (for assets that should be distributed to controller nodes). This new output format is intended to align with a modified asset distribution style in Typhoon.
* Lay the groundwork for `assets_dir` to become optional. The output map provides output variable access to the minimal assets that are required for bootstrap
* Assets that aren't required for bootstrap itself (e.g. the etcd CA key) but can be used by admins may later be added as specific output variables to further reduce asset_dir use

Background:

* `terraform-render-bootstrap` rendered assets were previously only provided by rendering files to an `asset_dir`. This was neccessary, but created a responsibility to maintain those assets on the machine where terraform apply was run