### PR TITLE
Change asset_dir variable from required to optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ module "bootstrap" {
   cluster_name = "example"
   api_servers = ["node1.example.com"]
   etcd_servers = ["node1.example.com"]
-  asset_dir = "/home/core/clusters/mycluster"
 }
 ```
 

--- a/auth.tf
+++ b/auth.tf
@@ -32,18 +32,24 @@ data "template_file" "kubeconfig-admin" {
 
 # Generated kubeconfig for Kubelets
 resource "local_file" "kubeconfig-kubelet" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = data.template_file.kubeconfig-kubelet.rendered
   filename = "${var.asset_dir}/auth/kubeconfig-kubelet"
 }
 
 # Generated admin kubeconfig to bootstrap control plane
 resource "local_file" "kubeconfig-admin" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = data.template_file.kubeconfig-admin.rendered
   filename = "${var.asset_dir}/auth/kubeconfig"
 }
 
 # Generated admin kubeconfig in a file named after the cluster
 resource "local_file" "kubeconfig-admin-named" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = data.template_file.kubeconfig-admin.rendered
   filename = "${var.asset_dir}/auth/${var.cluster_name}-config"
 }

--- a/conditional.tf
+++ b/conditional.tf
@@ -56,7 +56,7 @@ locals {
 
 # flannel manifests
 resource "local_file" "flannel-manifests" {
-  for_each = local.flannel_manifests
+  for_each = var.asset_dir == "" ? {} : local.flannel_manifests
 
   filename = "${var.asset_dir}/${each.key}"
   content  = each.value
@@ -64,7 +64,7 @@ resource "local_file" "flannel-manifests" {
 
 # Calico manifests
 resource "local_file" "calico-manifests" {
-  for_each = local.calico_manifests
+  for_each = var.asset_dir == "" ? {} : local.calico_manifests
 
   filename = "${var.asset_dir}/${each.key}"
   content  = each.value
@@ -72,7 +72,7 @@ resource "local_file" "calico-manifests" {
 
 # kube-router manifests
 resource "local_file" "kube-router-manifests" {
-  for_each = local.kube_router_manifests
+  for_each = var.asset_dir == "" ? {} : local.kube_router_manifests
 
   filename = "${var.asset_dir}/${each.key}"
   content  = each.value

--- a/manifests.tf
+++ b/manifests.tf
@@ -39,7 +39,7 @@ locals {
 
 # Kubernetes static pod manifests
 resource "local_file" "static-manifests" {
-  for_each = local.static_manifests
+  for_each = var.asset_dir == "" ? {} : local.static_manifests
 
   content  = each.value
   filename = "${var.asset_dir}/${each.key}"
@@ -47,7 +47,7 @@ resource "local_file" "static-manifests" {
 
 # Kubernetes control plane manifests
 resource "local_file" "manifests" {
-  for_each = local.manifests
+  for_each = var.asset_dir == "" ? {} : local.manifests
 
   content  = each.value
   filename = "${var.asset_dir}/${each.key}"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,5 +1,4 @@
 cluster_name = "example"
 api_servers = ["node1.example.com"]
 etcd_servers = ["node1.example.com"]
-asset_dir = "/home/core/mycluster"
 networking = "flannel"

--- a/tls-aggregation.tf
+++ b/tls-aggregation.tf
@@ -40,14 +40,14 @@ resource "tls_self_signed_cert" "aggregation-ca" {
 }
 
 resource "local_file" "aggregation-ca-key" {
-  count = var.enable_aggregation ? 1 : 0
+  count = var.enable_aggregation && var.asset_dir != "" ? 1 : 0
 
   content  = tls_private_key.aggregation-ca[0].private_key_pem
   filename = "${var.asset_dir}/tls/aggregation-ca.key"
 }
 
 resource "local_file" "aggregation-ca-crt" {
-  count = var.enable_aggregation ? 1 : 0
+  count = var.enable_aggregation && var.asset_dir != "" ? 1 : 0
 
   content  = tls_self_signed_cert.aggregation-ca[0].cert_pem
   filename = "${var.asset_dir}/tls/aggregation-ca.crt"
@@ -93,14 +93,14 @@ resource "tls_locally_signed_cert" "aggregation-client" {
 }
 
 resource "local_file" "aggregation-client-key" {
-  count = var.enable_aggregation ? 1 : 0
+  count = var.enable_aggregation && var.asset_dir != "" ? 1 : 0
 
   content  = tls_private_key.aggregation-client[0].private_key_pem
   filename = "${var.asset_dir}/tls/aggregation-client.key"
 }
 
 resource "local_file" "aggregation-client-crt" {
-  count = var.enable_aggregation ? 1 : 0
+  count = var.enable_aggregation && var.asset_dir != "" ? 1 : 0
 
   content  = tls_locally_signed_cert.aggregation-client[0].cert_pem
   filename = "${var.asset_dir}/tls/aggregation-client.crt"

--- a/tls-etcd.tf
+++ b/tls-etcd.tf
@@ -41,18 +41,24 @@ resource "tls_self_signed_cert" "etcd-ca" {
 
 # etcd-ca.crt
 resource "local_file" "etcd_ca_crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_self_signed_cert.etcd-ca.cert_pem
   filename = "${var.asset_dir}/tls/etcd-ca.crt"
 }
 
 # etcd-client-ca.crt
 resource "local_file" "etcd_client_ca_crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_self_signed_cert.etcd-ca.cert_pem
   filename = "${var.asset_dir}/tls/etcd-client-ca.crt"
 }
 
 # etcd-ca.key
 resource "local_file" "etcd_ca_key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.etcd-ca.private_key_pem
   filename = "${var.asset_dir}/tls/etcd-ca.key"
 }
@@ -99,12 +105,16 @@ resource "tls_locally_signed_cert" "client" {
 
 # etcd-client.crt
 resource "local_file" "etcd_client_crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_locally_signed_cert.client.cert_pem
   filename = "${var.asset_dir}/tls/etcd-client.crt"
 }
 
 # etcd-client.key
 resource "local_file" "etcd_client_key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.client.private_key_pem
   filename = "${var.asset_dir}/tls/etcd-client.key"
 }
@@ -151,18 +161,24 @@ resource "tls_locally_signed_cert" "server" {
 
 # server-ca.crt
 resource "local_file" "etcd_server_ca_crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_self_signed_cert.etcd-ca.cert_pem
   filename = "${var.asset_dir}/tls/etcd/server-ca.crt"
 }
 
 # server.crt
 resource "local_file" "etcd_server_crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_locally_signed_cert.server.cert_pem
   filename = "${var.asset_dir}/tls/etcd/server.crt"
 }
 
 # server.key
 resource "local_file" "etcd_server_key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.server.private_key_pem
   filename = "${var.asset_dir}/tls/etcd/server.key"
 }
@@ -205,18 +221,24 @@ resource "tls_locally_signed_cert" "peer" {
 
 # peer-ca.crt
 resource "local_file" "etcd_peer_ca_crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_self_signed_cert.etcd-ca.cert_pem
   filename = "${var.asset_dir}/tls/etcd/peer-ca.crt"
 }
 
 # peer.crt
 resource "local_file" "etcd_peer_crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_locally_signed_cert.peer.cert_pem
   filename = "${var.asset_dir}/tls/etcd/peer.crt"
 }
 
 # peer.key
 resource "local_file" "etcd_peer_key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.peer.private_key_pem
   filename = "${var.asset_dir}/tls/etcd/peer.key"
 }

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -37,11 +37,15 @@ resource "tls_self_signed_cert" "kube-ca" {
 }
 
 resource "local_file" "kube-ca-key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.kube-ca.private_key_pem
   filename = "${var.asset_dir}/tls/ca.key"
 }
 
 resource "local_file" "kube-ca-crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_self_signed_cert.kube-ca.cert_pem
   filename = "${var.asset_dir}/tls/ca.crt"
 }
@@ -93,11 +97,15 @@ resource "tls_locally_signed_cert" "apiserver" {
 }
 
 resource "local_file" "apiserver-key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.apiserver.private_key_pem
   filename = "${var.asset_dir}/tls/apiserver.key"
 }
 
 resource "local_file" "apiserver-crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_locally_signed_cert.apiserver.cert_pem
   filename = "${var.asset_dir}/tls/apiserver.crt"
 }
@@ -136,11 +144,15 @@ resource "tls_locally_signed_cert" "admin" {
 }
 
 resource "local_file" "admin-key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.admin.private_key_pem
   filename = "${var.asset_dir}/tls/admin.key"
 }
 
 resource "local_file" "admin-crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_locally_signed_cert.admin.cert_pem
   filename = "${var.asset_dir}/tls/admin.crt"
 }
@@ -153,11 +165,15 @@ resource "tls_private_key" "service-account" {
 }
 
 resource "local_file" "service-account-key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.service-account.private_key_pem
   filename = "${var.asset_dir}/tls/service-account.key"
 }
 
 resource "local_file" "service-account-crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.service-account.public_key_pem
   filename = "${var.asset_dir}/tls/service-account.pub"
 }
@@ -197,11 +213,15 @@ resource "tls_locally_signed_cert" "kubelet" {
 }
 
 resource "local_file" "kubelet-key" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_private_key.kubelet.private_key_pem
   filename = "${var.asset_dir}/tls/kubelet.key"
 }
 
 resource "local_file" "kubelet-crt" {
+  count = var.asset_dir == "" ? 0 : 1
+
   content  = tls_locally_signed_cert.kubelet.cert_pem
   filename = "${var.asset_dir}/tls/kubelet.crt"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,7 @@ variable "etcd_servers" {
 variable "asset_dir" {
   type        = string
   description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
+  default     = ""
 }
 
 variable "cloud_provider" {


### PR DESCRIPTION
* `asset_dir` is an absolute path to a directory where generated assets from terraform-render-bootstrap are written (sensitive)
* Change `asset_dir` to default to "" so no assets are written (favor Terraform output mechanisms). Previously, asset_dir was required so all users set some path. To take advantage of the new optionality, remove asset_dir or set it to ""