### PR TITLE
Restore kube-controller-manager settings lost in static pod migration

### DIFF
--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -21,16 +21,18 @@ spec:
     - /hyperkube
     - kube-controller-manager
     - --allocate-node-cidrs=true
-    - --cluster-cidr=${pod_cidr}
-    - --service-cluster-ip-range=${service_cidr}
     - --cloud-provider=${cloud_provider}
+    - --cluster-cidr=${pod_cidr}
     - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
     - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
     - --configure-cloud-routes=false
+    - --flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --leader-elect=true
+    - --pod-eviction-timeout=1m
     - --root-ca-file=/etc/kubernetes/secrets/ca.crt
     - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+    - --service-cluster-ip-range=${service_cidr}
     livenessProbe:
       httpGet:
         scheme: HTTPS


### PR DESCRIPTION
* Migration from a self-hosted to a static pod control plane dropped
a few kube-controller-manager customizations
* Reduce kube-controller-manager --pod-eviction-timeout from 5m to 1m
to move pods more quickly when nodes are preempted
* Fix flex-volume-plugin-dir since the Kubernetes default points to
a read-only filesystem on Container Linux / Fedora CoreOS

Related:

* https://github.com/poseidon/terraform-render-bootstrap/pull/148
* https://github.com/poseidon/terraform-render-bootstrap/commit/7b06557b7afe33b7d6e676f5d9aaefda6c3599d3