### PR TITLE
Update CoreDNS from v1.6.5 to v1.6.6

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -76,7 +76,7 @@ variable "container_images" {
     flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router = "cloudnativelabs/kube-router:v0.3.2"
     hyperkube   = "k8s.gcr.io/hyperkube:v1.17.0"
-    coredns     = "k8s.gcr.io/coredns:1.6.5"
+    coredns     = "k8s.gcr.io/coredns:1.6.6"
   }
 }
 


### PR DESCRIPTION
* * https://coredns.io/2019/12/11/coredns-1.6.6-release/