### PR TITLE
Configure kube-proxy to serve /metrics on 0.0.0.0:10249

### DIFF
--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -40,12 +40,18 @@ spec:
         - --cluster-cidr=${pod_cidr}
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --metrics-bind-address=0.0.0.0
         - --proxy-mode=ipvs
         env:
           - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+        ports:
+        - name: metrics
+          containerPort: 10249
+        - name: health
+          containerPort: 10256
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
* Set kube-proxy --metrics-bind-address to 0.0.0.0 (default 127.0.0.1) so Prometheus metrics can be scraped
* Add pod port list (informational only)
* Require node firewall rules to be updated before scrapes can succeed