### PR TITLE
Update Calico from v3.11.1 to v3.11.2

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -70,8 +70,8 @@ variable "container_images" {
   description = "Container images to use"
 
   default = {
-    calico      = "quay.io/calico/node:v3.11.1"
-    calico_cni  = "quay.io/calico/cni:v3.11.1"
+    calico      = "quay.io/calico/node:v3.11.2"
+    calico_cni  = "quay.io/calico/cni:v3.11.2"
     flannel     = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router = "cloudnativelabs/kube-router:v0.3.2"


### PR DESCRIPTION
* https://docs.projectcalico.org/v3.11/release-notes/