### PR TITLE
Update Calico from v3.12.0 to v3.13.1

### DIFF
--- a/resources/calico/cluster-role.yaml
+++ b/resources/calico/cluster-role.yaml
@@ -107,3 +107,11 @@ rules:
       - blockaffinities
     verbs:
       - watch
+  # calico-node has hardcoded kubeadm assumptions :(
+  # https://github.com/projectcalico/node/pull/417
+  # https://github.com/projectcalico/calico/pull/3211
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get

--- a/variables.tf
+++ b/variables.tf
@@ -70,8 +70,8 @@ variable "container_images" {
   description = "Container images to use"
 
   default = {
-    calico      = "quay.io/calico/node:v3.12.0"
-    calico_cni  = "quay.io/calico/cni:v3.12.0"
+    calico      = "quay.io/calico/node:v3.13.1"
+    calico_cni  = "quay.io/calico/cni:v3.13.1"
     flannel     = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router = "cloudnativelabs/kube-router:v0.3.2"


### PR DESCRIPTION
* https://docs.projectcalico.org/v3.13/release-notes/