### PR TITLE
Switch from upstream hyperkube to upstream component images

### DIFF
--- a/manifests.tf
+++ b/manifests.tf
@@ -6,7 +6,10 @@ locals {
     "static-manifests/${name}" => templatefile(
       "${path.module}/resources/static-manifests/${name}",
       {
-        hyperkube_image   = var.container_images["hyperkube"]
+        kube_apiserver_image          = var.container_images["kube_apiserver"]
+        kube_controller_manager_image = var.container_images["kube_controller_manager"]
+        kube_scheduler_image          = var.container_images["kube_scheduler"]
+
         etcd_servers      = join(",", formatlist("https://%s:2379", var.etcd_servers))
         cloud_provider    = var.cloud_provider
         pod_cidr          = var.pod_cidr
@@ -24,7 +27,7 @@ locals {
     "manifests/${name}" => templatefile(
       "${path.module}/resources/manifests/${name}",
       {
-        hyperkube_image        = var.container_images["hyperkube"]
+        kube_proxy_image       = var.container_images["kube_proxy"]
         coredns_image          = var.container_images["coredns"]
         control_plane_replicas = max(2, length(var.etcd_servers))
         pod_cidr               = var.pod_cidr

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -33,9 +33,8 @@ spec:
         operator: Exists
       containers:
       - name: kube-proxy
-        image: ${hyperkube_image}
+        image: ${kube_proxy_image}
         command:
-        - ./hyperkube
         - kube-proxy
         - --cluster-cidr=${pod_cidr}
         - --hostname-override=$(NODE_NAME)

--- a/resources/static-manifests/kube-apiserver.yaml
+++ b/resources/static-manifests/kube-apiserver.yaml
@@ -16,9 +16,8 @@ spec:
     runAsUser: 65534
   containers:
   - name: kube-apiserver
-    image: ${hyperkube_image}
+    image: ${kube_apiserver_image}
     command:
-    - /hyperkube
     - kube-apiserver
     - --advertise-address=$(POD_IP)
     - --allow-privileged=true

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -16,9 +16,8 @@ spec:
     runAsUser: 65534
   containers:
   - name: kube-controller-manager
-    image: ${hyperkube_image}
+    image: ${kube_controller_manager_image}
     command:
-    - /hyperkube
     - kube-controller-manager
     - --allocate-node-cidrs=true
     - --cloud-provider=${cloud_provider}

--- a/resources/static-manifests/kube-scheduler.yaml
+++ b/resources/static-manifests/kube-scheduler.yaml
@@ -16,9 +16,8 @@ spec:
     runAsUser: 65534
   containers:
   - name: kube-scheduler
-    image: ${hyperkube_image}
+    image: ${kube_scheduler_image}
     command:
-    - /hyperkube
     - kube-scheduler
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --leader-elect=true

--- a/variables.tf
+++ b/variables.tf
@@ -70,13 +70,17 @@ variable "container_images" {
   description = "Container images to use"
 
   default = {
-    calico      = "quay.io/calico/node:v3.13.1"
-    calico_cni  = "quay.io/calico/cni:v3.13.1"
-    flannel     = "quay.io/coreos/flannel:v0.11.0-amd64"
-    flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
+    calico                  = "quay.io/calico/node:v3.13.1"
+    calico_cni              = "quay.io/calico/cni:v3.13.1"
+    coredns                 = "k8s.gcr.io/coredns:1.6.7"
+    flannel                 = "quay.io/coreos/flannel:v0.11.0-amd64"
+    flannel_cni             = "quay.io/coreos/flannel-cni:v0.3.0"
+    kube_apiserver          = "k8s.gcr.io/kube-apiserver:v1.17.4"
+    kube_controller_manager = "k8s.gcr.io/kube-controller-manager:v1.17.4"
+    kube_scheduler          = "k8s.gcr.io/kube-scheduler:v1.17.4"
+    kube_proxy              = "k8s.gcr.io/kube-proxy:v1.17.4"
+    # experimental
     kube_router = "cloudnativelabs/kube-router:v0.3.2"
-    hyperkube   = "k8s.gcr.io/hyperkube:v1.17.4"
-    coredns     = "k8s.gcr.io/coredns:1.6.7"
   }
 }
 


### PR DESCRIPTION
* Kubernetes plans to stop releasing the hyperkube image in the future.
* Upstream will continue releasing container images for `kube-apiserver`, `kube-controller-manager`, `kube-proxy`, and `kube-scheduler`. Typhoon will use these images
* Upstream will release the kubelet as a binary for distros to package, either as a traditional DEB/RPP or as a container image for container-optimized operating systems. Typhoon will take on the packaging of Kubelet and its dependencies as a new container image (alongside kubectl)

Rel: https://github.com/kubernetes/kubernetes/pull/88676
New Kubelet: https://github.com/poseidon/kubelet