### PR TITLE
Fix Calico node crash loop on Pod restart

### DIFF
--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -61,6 +61,9 @@ spec:
                   key: veth_mtu
             - name: SLEEP
               value: "false"
+          securityContext:
+            seLinuxOptions:
+              level: "s0"
           volumeMounts:
             - name: cni-bin-dir
               mountPath: /host/opt/cni/bin


### PR DESCRIPTION
* Set a consistent MCS level/range for Calico install-cni
* Note: Rebooting a node was a workaround, because Kubelet relabels /etc/kubernetes(/cni/net.d)

Background:

* On SELinux enforcing systems, the Calico CNI install-cni container ran with default SELinux context and a random MCS pair. install-cni places CNI configs by first creating a temporary file and then moving them into place, which means the file MCS categories depend on the containers SELinux context.
* calico-node Pod restarts creates a new install-cni container with a different MCS pair that cannot access the earlier written file (it places configs every time), causing the init container to error and calico-node to crash loop
* https://github.com/projectcalico/cni-plugin/issues/874

```
mv: inter-device move failed: '/calico.conf.tmp' to
'/host/etc/cni/net.d/10-calico.conflist'; unable to remove target:
Permission denied
Failed to mv files. This may be caused by selinux configuration on the
host, or something else.
```

Note, this isn't a host SELinux configuration issue.