### PR TITLE
Remove unused Kubelet certificate and key pair

### DIFF
--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -195,34 +195,3 @@ resource "tls_cert_request" "kubelet" {
   }
 }
 
-resource "tls_locally_signed_cert" "kubelet" {
-  cert_request_pem = tls_cert_request.kubelet.cert_request_pem
-
-  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
-  ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
-  ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
-
-  validity_period_hours = 8760
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-    "client_auth",
-  ]
-}
-
-resource "local_file" "kubelet-key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.kubelet.private_key_pem
-  filename = "${var.asset_dir}/tls/kubelet.key"
-}
-
-resource "local_file" "kubelet-crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_locally_signed_cert.kubelet.cert_pem
-  filename = "${var.asset_dir}/tls/kubelet.crt"
-}
-


### PR DESCRIPTION
* Kubelet certificate and key pair in state (not output or distributed via `ssh.tf`) are not needed after with Kubelet TLS bootstrap
* Kubelet TLS bootstrap added in https://github.com/poseidon/terraform-render-bootstrap/pull/185

Fix https://github.com/poseidon/typhoon/issues/757