### PR TITLE
Rename controller node label and NoSchedule taint

### DIFF
--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: calico-node
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/controller
         operator: Exists
       - key: node.kubernetes.io/not-ready
         operator: Exists

--- a/resources/flannel/daemonset.yaml
+++ b/resources/flannel/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: flannel
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/controller
         operator: Exists
       - key: node.kubernetes.io/not-ready
         operator: Exists

--- a/resources/kube-router/daemonset.yaml
+++ b/resources/kube-router/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/controller
         operator: Exists
       - key: node.kubernetes.io/not-ready
         operator: Exists

--- a/resources/manifests/coredns/deployment.yaml
+++ b/resources/manifests/coredns/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           - weight: 100
             preference:
               matchExpressions:
-              - key: node.kubernetes.io/master
+              - key: node.kubernetes.io/controller
                 operator: Exists
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -50,7 +50,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/controller
           effect: NoSchedule
       containers:
         - name: coredns

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -27,7 +27,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-proxy
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/controller
         operator: Exists
       - key: node.kubernetes.io/not-ready
         operator: Exists


### PR DESCRIPTION
* Use node label `node.kubernetes.io/controller` to select controller nodes (action required)
* Tolerate node taint `node-role.kubernetes.io/controller` for workloads that should run on controller nodes. Don't tolerate `node-role.kubernetes.io/master` (action required)