### PR TITLE
Add NET_ADMIN capability to fix flannel on bare metal FCOS

### DIFF
--- a/resources/flannel/daemonset.yaml
+++ b/resources/flannel/daemonset.yaml
@@ -51,6 +51,8 @@ spec:
                   fieldPath: status.podIP
           securityContext:
             privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Without the

```
capabilities:
  add: ["NET_ADMIN"]
```

services in the Kubernetes cluster are broken. For example, when accessing Kubernetes dashboard

```
Error trying to reach service: 'dial tcp 10.2.2.2:8443: i/o timeout'
```

Running Typhoon with **v1.18.5** Kubernetes on bare metal Fedora CoreOS cluster.

After adding `NET_ADMIN` capability and waiting for flannel pods restarts, services are working again.

Default template also contains this capability:

https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml