### PR TITLE
Add volumes for /run/xtables.lock

### DIFF
--- a/resources/flannel/daemonset.yaml
+++ b/resources/flannel/daemonset.yaml
@@ -59,6 +59,9 @@ spec:
               mountPath: /etc/kube-flannel/
             - name: run-flannel
               mountPath: /run/flannel
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+              readOnly: false
         - name: install-cni
           image: ${flannel_cni_image}
           command: ["/install-cni.sh"]
@@ -87,3 +90,7 @@ spec:
         - name: cni-conf-dir
           hostPath:
             path: /etc/kubernetes/cni/net.d
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -73,6 +73,9 @@ spec:
         - name: ssl-certs-host
           mountPath: /etc/ssl/certs
           readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+          readOnly: false
       volumes:
       - name: kubeconfig
         configMap:
@@ -83,3 +86,7 @@ spec:
       - name: ssl-certs-host
         hostPath:
           path: ${trusted_certs_dir}
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate


### PR DESCRIPTION
To prevent race conditions when multiple applications want to create/modify iptables rules.
Calico and Cilium already have these volumes.

This PR adds this volume also to flannel and kube-proxy.