### PR TITLE
Update from coreos/flannel-cni to poseidon/flannel-cni

### DIFF
--- a/resources/flannel/daemonset.yaml
+++ b/resources/flannel/daemonset.yaml
@@ -32,6 +32,21 @@ spec:
       - key: ${key}
         operator: Exists
       %{~ endfor ~}
+      initContainers:
+        - name: install-cni
+          image: ${flannel_cni_image}
+          command: ["/install-cni.sh"]
+          env:
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: flannel-config
+                  key: cni-conf.json
+          volumeMounts:
+            - name: cni-bin-dir
+              mountPath: /host/opt/cni/bin/
+            - name: cni-conf-dir
+              mountPath: /host/etc/cni/net.d
       containers:
         - name: flannel
           image: ${flannel_image}
@@ -59,20 +74,6 @@ spec:
               mountPath: /etc/kube-flannel/
             - name: run-flannel
               mountPath: /run/flannel
-        - name: install-cni
-          image: ${flannel_cni_image}
-          command: ["/install-cni.sh"]
-          env:
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: flannel-config
-                  key: cni-conf.json
-          volumeMounts:
-            - name: cni-bin-dir
-              mountPath: /host/opt/cni/bin/
-            - name: cni-conf-dir
-              mountPath: /host/etc/cni/net.d
       volumes:
         - name: flannel-config
           configMap:

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "container_images" {
     calico_cni              = "quay.io/calico/cni:v3.15.1"
     coredns                 = "k8s.gcr.io/coredns:1.7.0"
     flannel                 = "quay.io/coreos/flannel:v0.12.0-amd64"
-    flannel_cni             = "quay.io/coreos/flannel-cni:v0.3.0"
+    flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.0"
     kube_apiserver          = "k8s.gcr.io/kube-apiserver:v1.18.6"
     kube_controller_manager = "k8s.gcr.io/kube-controller-manager:v1.18.6"
     kube_scheduler          = "k8s.gcr.io/kube-scheduler:v1.18.6"


### PR DESCRIPTION
* Update CNI plugins from v0.6.0 to v0.8.6 to fix several CVEs
* Update the base image to alpine:3.12
* Use `flannel-cni` as an init container and remove sleep
* Add Linux ARM64 and multi-arch container images
* https://github.com/poseidon/flannel-cni
* https://quay.io/repository/poseidon/flannel-cni

Background

* Switch from github.com/coreos/flannel-cni v0.3.0 which was last published by me in 2017 and which is no longer accessible to me to maintain or patch
* Port to the poseidon/flannel-cni rewrite, which releases v0.4.0 to continue the prior release numbering