### PR TITLE
Allow leader election among Cilium operator replicas

### DIFF
--- a/resources/cilium/cluster-role.yaml
+++ b/resources/cilium/cluster-role.yaml
@@ -35,14 +35,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
@@ -57,7 +49,23 @@ rules:
   - ciliumidentities/status
   verbs:
   - '*'
-
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+# Cilium leader elects if among multiple operator replicas
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/resources/cilium/deployment.yaml
+++ b/resources/cilium/deployment.yaml
@@ -69,6 +69,13 @@ spec:
         - name: config
           mountPath: /tmp/cilium/config-map
           readOnly: true
+      topologySpreadConstraints:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              name: cilium-operator
+          maxSkew: 1
+          whenUnsatisfiable: DoNotSchedule
       volumes:
       # Read configuration
       - name: config


### PR DESCRIPTION
* Allow Cilium operator Pods to leader elect when Deployment has more than one replica
* Use topology spread constraint to keep multiple operators from running on the same node (pods bind hostNetwork ports)