### PR TITLE
Relax Terraform version constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
   required_providers {
     local    = "~> 1.2"
     random   = "~> 2.2"


### PR DESCRIPTION
* bootstrap uses only Hashicorp Terraform modules, allow Terraform v0.13.x usage