### PR TITLE
Change seccomp annotations to Pod seccompProfile

### DIFF
--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -17,11 +17,12 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: calico-node
       tolerations:
       - key: node-role.kubernetes.io/controller

--- a/resources/cilium/daemonset.yaml
+++ b/resources/cilium/daemonset.yaml
@@ -17,12 +17,13 @@ spec:
     metadata:
       labels:
         k8s-app: cilium-agent
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       serviceAccountName: cilium-agent
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: node-role.kubernetes.io/controller
         operator: Exists

--- a/resources/cilium/deployment.yaml
+++ b/resources/cilium/deployment.yaml
@@ -16,12 +16,13 @@ spec:
     metadata:
       labels:
         name: cilium-operator
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
       priorityClassName: system-cluster-critical
       serviceAccountName: cilium-operator
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: node-role.kubernetes.io/controller
         operator: Exists

--- a/resources/flannel/daemonset.yaml
+++ b/resources/flannel/daemonset.yaml
@@ -17,12 +17,13 @@ spec:
     metadata:
       labels:
         k8s-app: flannel
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       serviceAccountName: flannel
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: node-role.kubernetes.io/controller
         operator: Exists

--- a/resources/manifests/coredns/deployment.yaml
+++ b/resources/manifests/coredns/deployment.yaml
@@ -21,8 +21,6 @@ spec:
       labels:
         tier: control-plane
         k8s-app: coredns
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       affinity:
         nodeAffinity:
@@ -48,6 +46,9 @@ spec:
                   - coredns
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: coredns
       tolerations:
         - key: node-role.kubernetes.io/controller

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -20,11 +20,12 @@ spec:
       labels:
         tier: node
         k8s-app: kube-proxy
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kube-proxy
       tolerations:
       - key: node-role.kubernetes.io/controller

--- a/resources/static-manifests/kube-apiserver.yaml
+++ b/resources/static-manifests/kube-apiserver.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     k8s-app: kube-apiserver
     tier: control-plane
-  annotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   hostNetwork: true
   priorityClassName: system-cluster-critical
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: kube-apiserver
     image: ${kube_apiserver_image}

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     k8s-app: kube-controller-manager
     tier: control-plane
-  annotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   hostNetwork: true
   priorityClassName: system-cluster-critical
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: kube-controller-manager
     image: ${kube_controller_manager_image}

--- a/resources/static-manifests/kube-scheduler.yaml
+++ b/resources/static-manifests/kube-scheduler.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     k8s-app: kube-scheduler
     tier: control-plane
-  annotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   hostNetwork: true
   priorityClassName: system-cluster-critical
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: kube-scheduler
     image: ${kube_scheduler_image}


### PR DESCRIPTION
* seccomp graduated to GA in Kubernetes v1.19. Support for seccomp alpha annotations will be removed in v1.22
* Replace seccomp annotations with the GA seccompProfile field in the PodTemplate securityContext
* Switch profile from `docker/default` to `runtime/default` (no effective change, since docker is the runtime)
* Verify with docker inspect SecurityOpt. Without the profile, you'd see `seccomp=unconfined`

Related: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#seccomp-graduates-to-general-availability