### PR TITLE
Fix output of Cilium manifests.

### DIFF
--- a/conditional.tf
+++ b/conditional.tf
@@ -73,3 +73,10 @@ resource "local_file" "calico-manifests" {
   content  = each.value
 }
 
+# Cilium manifests
+resource "local_file" "cilium-manifests" {
+  for_each = var.asset_dir == "" ? {} : local.cilium_manifests
+
+  filename = "${var.asset_dir}/${each.key}"
+  content  = each.value
+}


### PR DESCRIPTION
## Problem

When using the `networking = "cilium"` option the manifests are not rendered.


## Reproduction

Test config:

```hcl
# bootstrap.tf
module "bootstrap" {
  source = "git::https://github.com/poseidon/terraform-render-bootstrap.git?ref=7988fb7159cb81e2d080b365b147fe90542fd258"
 
  cluster_name = "example"
  api_servers  = ["node1.example.com"]
  etcd_servers = ["node1.example.com"]
  networking   = "cilium"
  asset_dir    = "./assets"
}
```

Generate:

```console
terraform init
terraform apply -auto-approve
```

Output (note the missing `manifests-networking`):

```diff
 └── assets
     ├── auth
     ├── manifests
     ├── static-manifests
     └── tls
```


## Reproduction with a fix

Test config:

```hcl
# bootstrap.tf
module "bootstrap" {
  source = "git::https://github.com/maikelvl/terraform-render-bootstrap.git?ref=99eb01ab323c074e90bec6bdd69701eb9a7cdb69"
                                  # ^^^^^^^^                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  cluster_name = "example"
  api_servers  = ["node1.example.com"]
  etcd_servers = ["node1.example.com"]
  networking   = "cilium"
  asset_dir    = "./assets"
}
```

Generate:

```console
terraform init
terraform apply -auto-approve
```

Output:

```diff
 └── assets
     ├── auth
     ├── manifests
+    ├── manifests-networking
     ├── static-manifests
     └── tls
```