### PR TITLE
Remove asset_dir variable and optional asset writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module "bootstrap" {
 }
 ```
 
-Generate the assets.
+Generate assets in Terraform state.
 
 ```sh
 terraform init
@@ -28,5 +28,13 @@ terraform plan
 terraform apply
 ```
 
-Find bootstrap assets rendered to the `asset_dir` path. That's it.
+To inspect and write assets locally (e.g. debugging) use the `assets_dist` Terraform output.
+
+```
+resource local_file "assets" {
+  for_each = module.bootstrap.assets_dist
+  filename = "some-assets/${each.key}"
+  content = each.value
+}
+```
 

--- a/auth.tf
+++ b/auth.tf
@@ -45,18 +45,3 @@ data "template_file" "kubeconfig-admin" {
   }
 }
 
-# Generated admin kubeconfig to bootstrap control plane
-resource "local_file" "kubeconfig-admin" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = data.template_file.kubeconfig-admin.rendered
-  filename = "${var.asset_dir}/auth/kubeconfig"
-}
-
-# Generated admin kubeconfig in a file named after the cluster
-resource "local_file" "kubeconfig-admin-named" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = data.template_file.kubeconfig-admin.rendered
-  filename = "${var.asset_dir}/auth/${var.cluster_name}-config"
-}

--- a/conditional.tf
+++ b/conditional.tf
@@ -57,26 +57,3 @@ locals {
   }
 }
 
-# flannel manifests
-resource "local_file" "flannel-manifests" {
-  for_each = var.asset_dir == "" ? {} : local.flannel_manifests
-
-  filename = "${var.asset_dir}/${each.key}"
-  content  = each.value
-}
-
-# Calico manifests
-resource "local_file" "calico-manifests" {
-  for_each = var.asset_dir == "" ? {} : local.calico_manifests
-
-  filename = "${var.asset_dir}/${each.key}"
-  content  = each.value
-}
-
-# Cilium manifests
-resource "local_file" "cilium-manifests" {
-  for_each = var.asset_dir == "" ? {} : local.cilium_manifests
-
-  filename = "${var.asset_dir}/${each.key}"
-  content  = each.value
-}

--- a/manifests.tf
+++ b/manifests.tf
@@ -43,22 +43,6 @@ locals {
   }
 }
 
-# Kubernetes static pod manifests
-resource "local_file" "static-manifests" {
-  for_each = var.asset_dir == "" ? {} : local.static_manifests
-
-  content  = each.value
-  filename = "${var.asset_dir}/${each.key}"
-}
-
-# Kubernetes control plane manifests
-resource "local_file" "manifests" {
-  for_each = var.asset_dir == "" ? {} : local.manifests
-
-  content  = each.value
-  filename = "${var.asset_dir}/${each.key}"
-}
-
 locals {
   aggregation_flags = <<EOF
 

--- a/tls-aggregation.tf
+++ b/tls-aggregation.tf
@@ -7,8 +7,6 @@ locals {
   } : {}
 }
 
-
-
 # Kubernetes Aggregation CA (i.e. front-proxy-ca)
 # Files: tls/{aggregation-ca.crt,aggregation-ca.key}
 
@@ -37,20 +35,6 @@ resource "tls_self_signed_cert" "aggregation-ca" {
     "digital_signature",
     "cert_signing",
   ]
-}
-
-resource "local_file" "aggregation-ca-key" {
-  count = var.enable_aggregation && var.asset_dir != "" ? 1 : 0
-
-  content  = tls_private_key.aggregation-ca[0].private_key_pem
-  filename = "${var.asset_dir}/tls/aggregation-ca.key"
-}
-
-resource "local_file" "aggregation-ca-crt" {
-  count = var.enable_aggregation && var.asset_dir != "" ? 1 : 0
-
-  content  = tls_self_signed_cert.aggregation-ca[0].cert_pem
-  filename = "${var.asset_dir}/tls/aggregation-ca.crt"
 }
 
 # Kubernetes apiserver (i.e. front-proxy-client)
@@ -90,19 +74,5 @@ resource "tls_locally_signed_cert" "aggregation-client" {
     "digital_signature",
     "client_auth",
   ]
-}
-
-resource "local_file" "aggregation-client-key" {
-  count = var.enable_aggregation && var.asset_dir != "" ? 1 : 0
-
-  content  = tls_private_key.aggregation-client[0].private_key_pem
-  filename = "${var.asset_dir}/tls/aggregation-client.key"
-}
-
-resource "local_file" "aggregation-client-crt" {
-  count = var.enable_aggregation && var.asset_dir != "" ? 1 : 0
-
-  content  = tls_locally_signed_cert.aggregation-client[0].cert_pem
-  filename = "${var.asset_dir}/tls/aggregation-client.crt"
 }
 

--- a/tls-etcd.tf
+++ b/tls-etcd.tf
@@ -39,30 +39,6 @@ resource "tls_self_signed_cert" "etcd-ca" {
   ]
 }
 
-# etcd-ca.crt
-resource "local_file" "etcd_ca_crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_self_signed_cert.etcd-ca.cert_pem
-  filename = "${var.asset_dir}/tls/etcd-ca.crt"
-}
-
-# etcd-client-ca.crt
-resource "local_file" "etcd_client_ca_crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_self_signed_cert.etcd-ca.cert_pem
-  filename = "${var.asset_dir}/tls/etcd-client-ca.crt"
-}
-
-# etcd-ca.key
-resource "local_file" "etcd_ca_key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.etcd-ca.private_key_pem
-  filename = "${var.asset_dir}/tls/etcd-ca.key"
-}
-
 # etcd Client (apiserver to etcd communication)
 
 resource "tls_private_key" "client" {
@@ -101,22 +77,6 @@ resource "tls_locally_signed_cert" "client" {
     "server_auth",
     "client_auth",
   ]
-}
-
-# etcd-client.crt
-resource "local_file" "etcd_client_crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_locally_signed_cert.client.cert_pem
-  filename = "${var.asset_dir}/tls/etcd-client.crt"
-}
-
-# etcd-client.key
-resource "local_file" "etcd_client_key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.client.private_key_pem
-  filename = "${var.asset_dir}/tls/etcd-client.key"
 }
 
 # etcd Server
@@ -159,30 +119,6 @@ resource "tls_locally_signed_cert" "server" {
   ]
 }
 
-# server-ca.crt
-resource "local_file" "etcd_server_ca_crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_self_signed_cert.etcd-ca.cert_pem
-  filename = "${var.asset_dir}/tls/etcd/server-ca.crt"
-}
-
-# server.crt
-resource "local_file" "etcd_server_crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_locally_signed_cert.server.cert_pem
-  filename = "${var.asset_dir}/tls/etcd/server.crt"
-}
-
-# server.key
-resource "local_file" "etcd_server_key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.server.private_key_pem
-  filename = "${var.asset_dir}/tls/etcd/server.key"
-}
-
 # etcd Peer
 
 resource "tls_private_key" "peer" {
@@ -217,29 +153,5 @@ resource "tls_locally_signed_cert" "peer" {
     "server_auth",
     "client_auth",
   ]
-}
-
-# peer-ca.crt
-resource "local_file" "etcd_peer_ca_crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_self_signed_cert.etcd-ca.cert_pem
-  filename = "${var.asset_dir}/tls/etcd/peer-ca.crt"
-}
-
-# peer.crt
-resource "local_file" "etcd_peer_crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_locally_signed_cert.peer.cert_pem
-  filename = "${var.asset_dir}/tls/etcd/peer.crt"
-}
-
-# peer.key
-resource "local_file" "etcd_peer_key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.peer.private_key_pem
-  filename = "${var.asset_dir}/tls/etcd/peer.key"
 }
 

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -36,20 +36,6 @@ resource "tls_self_signed_cert" "kube-ca" {
   ]
 }
 
-resource "local_file" "kube-ca-key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.kube-ca.private_key_pem
-  filename = "${var.asset_dir}/tls/ca.key"
-}
-
-resource "local_file" "kube-ca-crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_self_signed_cert.kube-ca.cert_pem
-  filename = "${var.asset_dir}/tls/ca.crt"
-}
-
 # Kubernetes API Server (tls/{apiserver.key,apiserver.crt})
 
 resource "tls_private_key" "apiserver" {
@@ -96,20 +82,6 @@ resource "tls_locally_signed_cert" "apiserver" {
   ]
 }
 
-resource "local_file" "apiserver-key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.apiserver.private_key_pem
-  filename = "${var.asset_dir}/tls/apiserver.key"
-}
-
-resource "local_file" "apiserver-crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_locally_signed_cert.apiserver.cert_pem
-  filename = "${var.asset_dir}/tls/apiserver.crt"
-}
-
 # Kubernetes Admin (tls/{admin.key,admin.crt})
 
 resource "tls_private_key" "admin" {
@@ -143,39 +115,11 @@ resource "tls_locally_signed_cert" "admin" {
   ]
 }
 
-resource "local_file" "admin-key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.admin.private_key_pem
-  filename = "${var.asset_dir}/tls/admin.key"
-}
-
-resource "local_file" "admin-crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_locally_signed_cert.admin.cert_pem
-  filename = "${var.asset_dir}/tls/admin.crt"
-}
-
 # Kubernete's Service Account (tls/{service-account.key,service-account.pub})
 
 resource "tls_private_key" "service-account" {
   algorithm = "RSA"
   rsa_bits  = "2048"
-}
-
-resource "local_file" "service-account-key" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.service-account.private_key_pem
-  filename = "${var.asset_dir}/tls/service-account.key"
-}
-
-resource "local_file" "service-account-crt" {
-  count = var.asset_dir == "" ? 0 : 1
-
-  content  = tls_private_key.service-account.public_key_pem
-  filename = "${var.asset_dir}/tls/service-account.pub"
 }
 
 # Kubelet

--- a/variables.tf
+++ b/variables.tf
@@ -13,12 +13,6 @@ variable "etcd_servers" {
   description = "List of URLs used to reach etcd servers."
 }
 
-variable "asset_dir" {
-  type        = string
-  description = "Absolute path to a directory where generated assets should be placed (contains secrets)"
-  default     = ""
-}
-
 variable "cloud_provider" {
   type        = string
   description = "The provider for cloud services (empty string for no provider)"

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,6 @@
 terraform {
   required_version = ">= 0.12.0, < 0.14.0"
   required_providers {
-    local    = "~> 1.2"
     random   = "~> 2.2"
     template = "~> 2.1"
     tls      = "~> 2.0"


### PR DESCRIPTION
* Originally, generated TLS certificates, manifests, and cluster "assets" written to local disk (`asset_dir`) during
terraform apply cluster bootstrap
* Typhoon v1.17.0 introduced bootstrapping using only Terraform state to store cluster assets, to avoid ever writing sensitive
materials to disk and improve automated use-cases. `asset_dir` was changed to optional and defaulted to "" (no writes)
* Typhoon v1.18.0 deprecated the `asset_dir` variable, removed docs, and announced it would be deleted in future.
* Remove the `asset_dir` variable

Cluster assets are now stored in Terraform state only. For those who wish to write those assets to local files, this is possible doing so explicitly.

```
resource local_file "assets" {
  for_each = module.bootstrap.assets_dist
  filename = "some-assets/${each.key}"
  content = each.value
}
```

Related:

* https://github.com/poseidon/typhoon/pull/595
* https://github.com/poseidon/typhoon/pull/678