### PR TITLE
use-service-account-credentials in kube-controller-manager

### DIFF
--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -33,6 +33,7 @@ spec:
     - --root-ca-file=/etc/kubernetes/secrets/ca.crt
     - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
     - --service-cluster-ip-range=${service_cidr}
+    - --use-service-account-credentials=true
     livenessProbe:
       httpGet:
         scheme: HTTPS


### PR DESCRIPTION
added the `--use-service-account-credentials=true` commandline argumet to the kube controller manager commandline. Seems to be the default on most other k8s distros and resolves an issue with platforms like [dapr](https://github.com/dapr/dapr/issues/2353) that use a `MutatingWebHook / AdmissionReview` flow to inject containers into pods. 