### PR TITLE
Restore kube-controller-manager --use-service-account-credentials

### DIFF
--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -33,6 +33,7 @@ spec:
     - --root-ca-file=/etc/kubernetes/secrets/ca.crt
     - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
     - --service-cluster-ip-range=${service_cidr}
+    - --use-service-account-credentials=true
     livenessProbe:
       httpGet:
         scheme: HTTPS


### PR DESCRIPTION
* kube-controller-manager Pods can start control loops with credentials that have been granted relevant controller manager roles or using generated service accounts bound to each role
* During the migration of the control plane from self-hosted to static pods (https://github.com/poseidon/terraform-render-bootstrap/pull/148) the flag for using separate service accounts was inadvertently dropped
* Restore the --use-service-account-credentials flag used before v1.16

Related:

* https://kubernetes.io/docs/reference/access-authn-authz/rbac/#controller-roles
* https://github.com/poseidon/terraform-render-bootstrap/pull/225