### PR TITLE
Add TokenReview and TokenRequestProjection kube-apiserver flags

### DIFF
--- a/resources/static-manifests/kube-apiserver.yaml
+++ b/resources/static-manifests/kube-apiserver.yaml
@@ -24,9 +24,9 @@ spec:
     - --anonymous-auth=false
     - --authorization-mode=Node,RBAC
     - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+    - --cloud-provider=${cloud_provider}
     - --enable-admission-plugins=NodeRestriction
     - --enable-bootstrap-token-auth=true
-    - --cloud-provider=${cloud_provider}
     - --etcd-cafile=/etc/kubernetes/secrets/etcd-client-ca.crt
     - --etcd-certfile=/etc/kubernetes/secrets/etcd-client.crt
     - --etcd-keyfile=/etc/kubernetes/secrets/etcd-client.key
@@ -36,7 +36,9 @@ spec:
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname${aggregation_flags}
     - --secure-port=6443
+    - --service-account-issuer=https://kubernetes.default.svc.cluster.local
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
+    - --service-account-signing-key-file=/etc/kubernetes/secrets/service-account.key
     - --service-cluster-ip-range=${service_cidr}
     - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
     - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -21,11 +21,12 @@ spec:
     - kube-controller-manager
     - --allocate-node-cidrs=true
     - --cloud-provider=${cloud_provider}
+    - --client-ca-file=/etc/kubernetes/secrets/ca.crt
     - --cluster-cidr=${pod_cidr}
     - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
     - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
+    - --cluster-signing-duration=72h
     - --configure-cloud-routes=false
-    - --experimental-cluster-signing-duration=72h
     - --flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --leader-elect=true

--- a/resources/static-manifests/kube-scheduler.yaml
+++ b/resources/static-manifests/kube-scheduler.yaml
@@ -34,9 +34,9 @@ spec:
         cpu: 100m
     volumeMounts:
     - name: secrets
-      mountPath: /etc/kubernetes/secrets
+      mountPath: /etc/kubernetes/secrets/kubeconfig
       readOnly: true
   volumes:
   - name: secrets
     hostPath:
-      path: /etc/kubernetes/bootstrap-secrets
+      path: /etc/kubernetes/bootstrap-secrets/kubeconfig


### PR DESCRIPTION
* Add kube-apiserver flags for TokenReview and TokenRequestProjection (beta, defaults on) to allow using Service Account Token Volume Projection to create and mount service account tokens tied to a Pod's lifecycle
* Both features will be promoted from beta to stable in v1.20
* Rename `experimental-cluster-signing-duration` to just `cluster-signing-duration`

Rel:

* https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection