### PR TITLE
Generate kubeconfig's for kube-scheduler and kube-controller-manager

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -1,7 +1,60 @@
 locals {
-  # auth kubeconfig assets map
+  # component kubeconfigs assets map
   auth_kubeconfigs = {
-    "auth/kubeconfig" = data.template_file.kubeconfig-admin.rendered,
+    "auth/admin.conf" = data.template_file.kubeconfig-admin.rendered,
+    "auth/controller-manager.conf" = data.template_file.kubeconfig-controller-manager.rendered,
+    "auth/scheduler.conf" = data.template_file.kubeconfig-scheduler.rendered,
+  }
+}
+
+# Generated admin kubeconfig to bootstrap control plane
+data "template_file" "kubeconfig-admin" {
+  template = file("${path.module}/resources/kubeconfig-admin")
+
+  vars = {
+    name         = var.cluster_name
+    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    kubelet_cert = base64encode(tls_locally_signed_cert.admin.cert_pem)
+    kubelet_key  = base64encode(tls_private_key.admin.private_key_pem)
+    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
+  }
+}
+
+# Generated kube-controller-manager kubeconfig
+data "template_file" "kubeconfig-controller-manager" {
+  template = file("${path.module}/resources/kubeconfig-admin")
+
+  vars = {
+    name         = var.cluster_name
+    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    kubelet_cert = base64encode(tls_locally_signed_cert.controller-manager.cert_pem)
+    kubelet_key  = base64encode(tls_private_key.controller-manager.private_key_pem)
+    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
+  }
+}
+
+# Generated kube-controller-manager kubeconfig
+data "template_file" "kubeconfig-scheduler" {
+  template = file("${path.module}/resources/kubeconfig-admin")
+
+  vars = {
+    name         = var.cluster_name
+    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    kubelet_cert = base64encode(tls_locally_signed_cert.scheduler.cert_pem)
+    kubelet_key  = base64encode(tls_private_key.scheduler.private_key_pem)
+    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
+  }
+}
+
+# Generated kubeconfig to bootstrap Kubelets
+data "template_file" "kubeconfig-bootstrap" {
+  template = file("${path.module}/resources/kubeconfig-bootstrap")
+
+  vars = {
+    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
+    token_id     = random_string.bootstrap-token-id.result
+    token_secret = random_string.bootstrap-token-secret.result
   }
 }
 
@@ -17,31 +70,5 @@ resource random_string "bootstrap-token-secret" {
   length  = 16
   upper   = false
   special = false
-}
-
-# Generated kubeconfig to bootstrap Kubelets
-data "template_file" "kubeconfig-bootstrap" {
-  template = file("${path.module}/resources/kubeconfig-bootstrap")
-
-  vars = {
-    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
-    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
-    token_id     = random_string.bootstrap-token-id.result
-    token_secret = random_string.bootstrap-token-secret.result
-  }
-}
-
-
-# Generated admin kubeconfig to bootstrap control plane
-data "template_file" "kubeconfig-admin" {
-  template = file("${path.module}/resources/kubeconfig-admin")
-
-  vars = {
-    name         = var.cluster_name
-    ca_cert      = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
-    kubelet_cert = base64encode(tls_locally_signed_cert.admin.cert_pem)
-    kubelet_key  = base64encode(tls_private_key.admin.private_key_pem)
-    server       = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
-  }
 }
 

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
     - --cluster-signing-duration=72h
     - --configure-cloud-routes=false
     - --flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins
-    - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
+    - --kubeconfig=/etc/kubernetes/secrets/controller-manager.conf
     - --leader-elect=true
     - --pod-eviction-timeout=1m
     - --root-ca-file=/etc/kubernetes/secrets/ca.crt

--- a/resources/static-manifests/kube-scheduler.yaml
+++ b/resources/static-manifests/kube-scheduler.yaml
@@ -19,7 +19,7 @@ spec:
     image: ${kube_scheduler_image}
     command:
     - kube-scheduler
-    - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
+    - --kubeconfig=/etc/kubernetes/secrets/scheduler.conf
     - --leader-elect=true
     livenessProbe:
       httpGet:
@@ -34,9 +34,9 @@ spec:
         cpu: 100m
     volumeMounts:
     - name: secrets
-      mountPath: /etc/kubernetes/secrets/kubeconfig
+      mountPath: /etc/kubernetes/secrets/scheduler.conf
       readOnly: true
   volumes:
   - name: secrets
     hostPath:
-      path: /etc/kubernetes/bootstrap-secrets/kubeconfig
+      path: /etc/kubernetes/bootstrap-secrets/scheduler.conf

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -82,6 +82,70 @@ resource "tls_locally_signed_cert" "apiserver" {
   ]
 }
 
+# kube-controller-manager
+
+resource "tls_private_key" "controller-manager" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "tls_cert_request" "controller-manager" {
+  key_algorithm   = tls_private_key.controller-manager.algorithm
+  private_key_pem = tls_private_key.controller-manager.private_key_pem
+
+  subject {
+    common_name  = "system:kube-controller-manager"
+  }
+}
+
+resource "tls_locally_signed_cert" "controller-manager" {
+  cert_request_pem = tls_cert_request.controller-manager.cert_request_pem
+
+  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
+  ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
+
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
+  ]
+}
+
+# kube-scheduler
+
+resource "tls_private_key" "scheduler" {
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "tls_cert_request" "scheduler" {
+  key_algorithm   = tls_private_key.scheduler.algorithm
+  private_key_pem = tls_private_key.scheduler.private_key_pem
+
+  subject {
+    common_name  = "system:kube-scheduler"
+  }
+}
+
+resource "tls_locally_signed_cert" "scheduler" {
+  cert_request_pem = tls_cert_request.scheduler.cert_request_pem
+
+  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
+  ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
+
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
+  ]
+}
+
 # Kubernetes Admin (tls/{admin.key,admin.crt})
 
 resource "tls_private_key" "admin" {
@@ -120,22 +184,5 @@ resource "tls_locally_signed_cert" "admin" {
 resource "tls_private_key" "service-account" {
   algorithm = "RSA"
   rsa_bits  = "2048"
-}
-
-# Kubelet
-
-resource "tls_private_key" "kubelet" {
-  algorithm = "RSA"
-  rsa_bits  = "2048"
-}
-
-resource "tls_cert_request" "kubelet" {
-  key_algorithm   = tls_private_key.kubelet.algorithm
-  private_key_pem = tls_private_key.kubelet.private_key_pem
-
-  subject {
-    common_name  = "kubelet"
-    organization = "system:nodes"
-  }
 }
 


### PR DESCRIPTION
* Generate TLS client certificates for kube-scheduler and kube-controller-manager with `system:kube-scheduler` and
`system:kube-controller-manager` CNs 
* Template separate kubeconfigs for kube-scheduler and kube-controller manager (`scheduler.conf` and `controller-manager.conf`). Rename admin for clarity
* Before v1.16.0, Typhoon scheduled a self-hosted control plane, which allowed the steady-state kube-scheduler and kube-controller-manager to use a scoped ServiceAccount. With a static pod control plane, separate CN TLS client certificates are the nearest equiv.
* https://kubernetes.io/docs/setup/best-practices/certificates/
* Remove unused Kubelet certificate, TLS bootstrap is used instead