### PR TITLE
Rename bootstrap-secrets directory to pki

### DIFF
--- a/manifests.tf
+++ b/manifests.tf
@@ -46,9 +46,9 @@ locals {
 locals {
   aggregation_flags = <<EOF
 
-- --proxy-client-cert-file=/etc/kubernetes/secrets/aggregation-client.crt
-- --proxy-client-key-file=/etc/kubernetes/secrets/aggregation-client.key
-- --requestheader-client-ca-file=/etc/kubernetes/secrets/aggregation-ca.crt
+- --proxy-client-cert-file=/etc/kubernetes/pki/aggregation-client.crt
+- --proxy-client-key-file=/etc/kubernetes/pki/aggregation-client.key
+- --requestheader-client-ca-file=/etc/kubernetes/pki/aggregation-ca.crt
 - --requestheader-extra-headers-prefix=X-Remote-Extra-
 - --requestheader-group-headers=X-Remote-Group
 - --requestheader-username-headers=X-Remote-User

--- a/resources/static-manifests/kube-apiserver.yaml
+++ b/resources/static-manifests/kube-apiserver.yaml
@@ -23,25 +23,25 @@ spec:
     - --allow-privileged=true
     - --anonymous-auth=false
     - --authorization-mode=Node,RBAC
-    - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+    - --client-ca-file=/etc/kubernetes/pki/ca.crt
     - --cloud-provider=${cloud_provider}
     - --enable-admission-plugins=NodeRestriction
     - --enable-bootstrap-token-auth=true
-    - --etcd-cafile=/etc/kubernetes/secrets/etcd-client-ca.crt
-    - --etcd-certfile=/etc/kubernetes/secrets/etcd-client.crt
-    - --etcd-keyfile=/etc/kubernetes/secrets/etcd-client.key
+    - --etcd-cafile=/etc/kubernetes/pki/etcd-client-ca.crt
+    - --etcd-certfile=/etc/kubernetes/pki/etcd-client.crt
+    - --etcd-keyfile=/etc/kubernetes/pki/etcd-client.key
     - --etcd-servers=${etcd_servers}
     - --insecure-port=0
-    - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
-    - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
+    - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver.crt
+    - --kubelet-client-key=/etc/kubernetes/pki/apiserver.key
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname${aggregation_flags}
     - --secure-port=6443
     - --service-account-issuer=https://kubernetes.default.svc.cluster.local
-    - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
-    - --service-account-signing-key-file=/etc/kubernetes/secrets/service-account.key
+    - --service-account-key-file=/etc/kubernetes/pki/service-account.pub
+    - --service-account-signing-key-file=/etc/kubernetes/pki/service-account.key
     - --service-cluster-ip-range=${service_cidr}
-    - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
-    - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
+    - --tls-cert-file=/etc/kubernetes/pki/apiserver.crt
+    - --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
     env:
     - name: POD_IP
       valueFrom:
@@ -52,7 +52,7 @@ spec:
         cpu: 150m
     volumeMounts:
     - name: secrets
-      mountPath: /etc/kubernetes/secrets
+      mountPath: /etc/kubernetes/pki
       readOnly: true
     - name: ssl-certs-host
       mountPath: /etc/ssl/certs
@@ -60,7 +60,7 @@ spec:
   volumes:
   - name: secrets
     hostPath:
-      path: /etc/kubernetes/bootstrap-secrets
+      path: /etc/kubernetes/pki
   - name: ssl-certs-host
     hostPath:
       path: ${trusted_certs_dir}

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -21,18 +21,18 @@ spec:
     - kube-controller-manager
     - --allocate-node-cidrs=true
     - --cloud-provider=${cloud_provider}
-    - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+    - --client-ca-file=/etc/kubernetes/pki/ca.crt
     - --cluster-cidr=${pod_cidr}
-    - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
-    - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
+    - --cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt
+    - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
     - --cluster-signing-duration=72h
     - --configure-cloud-routes=false
     - --flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins
-    - --kubeconfig=/etc/kubernetes/secrets/controller-manager.conf
+    - --kubeconfig=/etc/kubernetes/pki/controller-manager.conf
     - --leader-elect=true
     - --pod-eviction-timeout=1m
-    - --root-ca-file=/etc/kubernetes/secrets/ca.crt
-    - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+    - --root-ca-file=/etc/kubernetes/pki/ca.crt
+    - --service-account-private-key-file=/etc/kubernetes/pki/service-account.key
     - --service-cluster-ip-range=${service_cidr}
     - --use-service-account-credentials=true
     livenessProbe:
@@ -48,7 +48,7 @@ spec:
         cpu: 150m
     volumeMounts:
     - name: secrets
-      mountPath: /etc/kubernetes/secrets
+      mountPath: /etc/kubernetes/pki
       readOnly: true
     - name: ssl-host
       mountPath: /etc/ssl/certs
@@ -56,7 +56,7 @@ spec:
   volumes:
   - name: secrets
     hostPath:
-      path: /etc/kubernetes/bootstrap-secrets
+      path: /etc/kubernetes/pki
   - name: ssl-host
     hostPath:
       path: ${trusted_certs_dir}

--- a/resources/static-manifests/kube-scheduler.yaml
+++ b/resources/static-manifests/kube-scheduler.yaml
@@ -19,7 +19,7 @@ spec:
     image: ${kube_scheduler_image}
     command:
     - kube-scheduler
-    - --kubeconfig=/etc/kubernetes/secrets/scheduler.conf
+    - --kubeconfig=/etc/kubernetes/pki/scheduler.conf
     - --leader-elect=true
     livenessProbe:
       httpGet:
@@ -34,9 +34,9 @@ spec:
         cpu: 100m
     volumeMounts:
     - name: secrets
-      mountPath: /etc/kubernetes/secrets/scheduler.conf
+      mountPath: /etc/kubernetes/pki/scheduler.conf
       readOnly: true
   volumes:
   - name: secrets
     hostPath:
-      path: /etc/kubernetes/bootstrap-secrets/scheduler.conf
+      path: /etc/kubernetes/pki/scheduler.conf


### PR DESCRIPTION
* Change control plane static pods to mount `/etc/kubernetes/pki`, instead of `/etc/kubernetes/bootstrap-secrets` to better reflect their purpose and match some loose conventions upstream
* Require TLS assets to be placed at `/etc/kubernetes/pki`, instead of `/etc/kubernetes/bootstrap-secrets` on hosts (breaking)
* Mount to `/etc/kubernetes/pki` (instead of `/etc/kubernetes/secrets`) to match the host naming (less surprise)
* https://kubernetes.io/docs/setup/best-practices/certificates/