### PR TITLE
Update required Terraform versions to v0.13 <= x < v0.15

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.13.0, < 0.15.0"
   required_providers {
     random   = "~> 2.2"
     template = "~> 2.1"


### PR DESCRIPTION
* Allow Terraform v0.13.x or v0.14.x to be used
* Drop support for Terraform v0.12 since Typhoon already requires v0.13+ https://github.com/poseidon/typhoon/pull/880