### PR TITLE
versions: allow v3 of tls and random providers

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,8 @@
 terraform {
   required_version = ">= 0.13.0, < 0.15.0"
   required_providers {
-    random   = "~> 2.2"
+    random   = ">= 2, < 4"
     template = "~> 2.1"
-    tls      = "~> 2.0"
+    tls      = ">= 2, < 4"
   }
 }


### PR DESCRIPTION
Providers `random` and `tls` have new versions available that use v2 of the provider SDK and drop support for Terraform 0.11. This allows these new versions so that this is not a breaking change but users who require these new versions don't get a conflict.

https://github.com/hashicorp/terraform-provider-random/blob/master/CHANGELOG.md#300-october-09-2020
https://github.com/hashicorp/terraform-provider-tls/blob/master/CHANGELOG.md#300-october-14-2020