### PR TITLE
Update Cilium from v1.9.6 to v1.10.0-rc1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -60,8 +60,8 @@ variable "container_images" {
   default = {
     calico                  = "quay.io/calico/node:v3.19.0"
     calico_cni              = "quay.io/calico/cni:v3.19.0"
-    cilium_agent            = "quay.io/cilium/cilium:v1.9.6"
-    cilium_operator         = "quay.io/cilium/operator-generic:v1.9.6"
+    cilium_agent            = "quay.io/cilium/cilium:v1.10.0-rc1"
+    cilium_operator         = "quay.io/cilium/operator-generic:v1.10.0-rc1"
     coredns                 = "k8s.gcr.io/coredns/coredns:v1.8.0"
     flannel                 = "quay.io/coreos/flannel:v0.13.0"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.2"


### PR DESCRIPTION
* Adds multi-arch container images and arm64 support!
* https://github.com/cilium/cilium/releases/tag/v1.10.0-rc1