### PR TITLE
Enable Cilium endpoint routes

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -1,9 +1,9 @@
 locals {
   # component kubeconfigs assets map
   auth_kubeconfigs = {
-    "auth/admin.conf" = data.template_file.kubeconfig-admin.rendered,
+    "auth/admin.conf"              = data.template_file.kubeconfig-admin.rendered,
     "auth/controller-manager.conf" = data.template_file.kubeconfig-controller-manager.rendered,
-    "auth/scheduler.conf" = data.template_file.kubeconfig-scheduler.rendered,
+    "auth/scheduler.conf"          = data.template_file.kubeconfig-scheduler.rendered,
   }
 }
 
@@ -59,14 +59,14 @@ data "template_file" "kubeconfig-bootstrap" {
 }
 
 # Generate a cryptographically random token id (public)
-resource random_password "bootstrap-token-id" {
+resource "random_password" "bootstrap-token-id" {
   length  = 6
   upper   = false
   special = false
 }
 
 # Generate a cryptographically random token secret
-resource random_password "bootstrap-token-secret" {
+resource "random_password" "bootstrap-token-secret" {
   length  = 16
   upper   = false
   special = false

--- a/resources/cilium/config.yaml
+++ b/resources/cilium/config.yaml
@@ -100,6 +100,7 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: vxlan
+  enable-endpoint-routes: "true"
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: default

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -94,7 +94,7 @@ resource "tls_cert_request" "controller-manager" {
   private_key_pem = tls_private_key.controller-manager.private_key_pem
 
   subject {
-    common_name  = "system:kube-controller-manager"
+    common_name = "system:kube-controller-manager"
   }
 }
 
@@ -126,7 +126,7 @@ resource "tls_cert_request" "scheduler" {
   private_key_pem = tls_private_key.scheduler.private_key_pem
 
   subject {
-    common_name  = "system:kube-scheduler"
+    common_name = "system:kube-scheduler"
   }
 }
 


### PR DESCRIPTION
* Fedora 34 / systemd 248 seem to have changes that affect service node-to-node traffic, specifically with Cilium. A workaround seems to be enabling endpoint routes

Rel: https://github.com/cilium/cilium/issues/10645