### PR TITLE
Update CoreDNS from v1.8.0 to v1.8.4

### DIFF
--- a/resources/manifests/coredns/cluster-role.yaml
+++ b/resources/manifests/coredns/cluster-role.yaml
@@ -14,6 +14,12 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - watch
   - apiGroups: [""]
     resources:
       - nodes

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "container_images" {
     calico_cni              = "quay.io/calico/cni:v3.19.1"
     cilium_agent            = "quay.io/cilium/cilium:v1.10.1"
     cilium_operator         = "quay.io/cilium/operator-generic:v1.10.1"
-    coredns                 = "k8s.gcr.io/coredns/coredns:v1.8.0"
+    coredns                 = "k8s.gcr.io/coredns/coredns:v1.8.4"
     flannel                 = "quay.io/coreos/flannel:v0.13.0"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.2"
     kube_apiserver          = "k8s.gcr.io/kube-apiserver:v1.21.2"


### PR DESCRIPTION
* https://coredns.io/2021/01/20/coredns-1.8.1-release/
* https://coredns.io/2021/02/23/coredns-1.8.2-release/
* https://coredns.io/2021/02/24/coredns-1.8.3-release/
* https://coredns.io/2021/05/28/coredns-1.8.4-release/

