### PR TITLE
Add Cilium init container to auto-mount cgroup2

### DIFF
--- a/resources/cilium/cluster-role.yaml
+++ b/resources/cilium/cluster-role.yaml
@@ -25,6 +25,21 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # to perform LB IP allocation for BGP
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
@@ -166,6 +181,7 @@ rules:
   - ciliumlocalredirectpolicies
   - ciliumlocalredirectpolicies/status
   - ciliumlocalredirectpolicies/finalizers
+  - ciliumegressnatpolicies
   verbs:
   - '*'
 

--- a/resources/cilium/daemonset.yaml
+++ b/resources/cilium/daemonset.yaml
@@ -34,6 +34,32 @@ spec:
         operator: Exists
       %{~ endfor ~}
       initContainers:
+      # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
+      # We use nsenter command with host's cgroup and mount namespaces enabled.
+      - name: mount-cgroup
+        image: ${cilium_agent_image}
+        command:
+          - sh
+          - -c
+          # The statically linked Go program binary is invoked to avoid any
+          # dependency on utilities like sh and mount that can be missing on certain
+          # distros installed on the underlying host. Copy the binary to the
+          # same directory where we install cilium cni plugin so that exec permissions
+          # are available.
+          - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount && nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "$${BIN_PATH}/cilium-mount" $CGROUP_ROOT; rm /hostbin/cilium-mount'
+        env:
+          - name: CGROUP_ROOT
+            value: /run/cilium/cgroupv2
+          - name: BIN_PATH
+            value: /opt/cni/bin
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: hostproc
+            mountPath: /hostproc
+          - name: cni-bin-dir
+            mountPath: /hostbin
+
       - name: clean-cilium-state
         image: ${cilium_agent_image}
         command:
@@ -56,6 +82,11 @@ spec:
           mountPropagation: HostToContainer
         - name: var-run-cilium
           mountPath: /var/run/cilium
+        # Required to mount cgroup filesystem from the host to cilium agent pod
+        - name: cilium-cgroup
+          mountPath: /run/cilium/cgroupv2
+          mountPropagation: HostToContainer
+
       containers:
       - name: cilium-agent
         image: ${cilium_agent_image}
@@ -86,6 +117,7 @@ spec:
               command:
               - "/cni-install.sh"
               - "--enable-debug=false"
+              - "--cni-exclusive=true"
           preStop:
             exec:
               command:
@@ -159,6 +191,15 @@ spec:
       - name: sys-fs-bpf
         hostPath:
           path: /sys/fs/bpf
+          type: DirectoryOrCreate
+      # Mount host cgroup2 filesystem
+      - name: hostproc
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: cilium-cgroup
+        hostPath:
+          path: /run/cilium/cgroupv2
           type: DirectoryOrCreate
       # Read configuration
       - name: config


### PR DESCRIPTION
* Add init container to auto-mount /sys/fs/cgroup cgroup2 at /run/cilium/cgroupv2 for the Cilium agent
* Enable CNI exclusive mode, to disable other configs found in /etc/cni/net.d/
* https://github.com/cilium/cilium/pull/16259