### PR TITLE
Disable kube-scheduler insecure port

### DIFF
--- a/resources/static-manifests/kube-apiserver.yaml
+++ b/resources/static-manifests/kube-apiserver.yaml
@@ -30,7 +30,6 @@ spec:
     - --etcd-certfile=/etc/kubernetes/pki/etcd-client.crt
     - --etcd-keyfile=/etc/kubernetes/pki/etcd-client.key
     - --etcd-servers=${etcd_servers}
-    - --insecure-port=0
     - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/pki/apiserver.key
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname${aggregation_flags}

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -42,7 +42,7 @@ spec:
         host: 127.0.0.1
         path: /healthz
         port: 10257
-      initialDelaySeconds: 15
+      initialDelaySeconds: 25
       timeoutSeconds: 15
       failureThreshold: 8
     resources:

--- a/resources/static-manifests/kube-scheduler.yaml
+++ b/resources/static-manifests/kube-scheduler.yaml
@@ -23,6 +23,7 @@ spec:
     - --authorization-kubeconfig=/etc/kubernetes/pki/scheduler.conf
     - --kubeconfig=/etc/kubernetes/pki/scheduler.conf
     - --leader-elect=true
+    - --port=0
     livenessProbe:
       httpGet:
         scheme: HTTPS


### PR DESCRIPTION
* Kubernetes v1.22.0 disables kube-controller-manager insecure port which was used internally for Prometheus metrics scraping
In Typhoon, we'll switch to using the https port which requires Prometheus present a bearer token
* Go ahead and disable the insecure port for kube-scheduler too, we'll configure Prometheus to scrape it with a bearer token as
well
* Remove unused kube-apiserver `--port` flag

Rel:

* https://github.com/kubernetes/kubernetes/pull/96216