### PR TITLE
Fix ClusterIP access when using Cilium

### DIFF
--- a/resources/cilium/config.yaml
+++ b/resources/cilium/config.yaml
@@ -126,6 +126,7 @@ data:
   masquerade: "true"
   # bpfMasquerade enables masquerading with BPF instead of iptables
   enable-bpf-masquerade: "true"
+  bpf-lb-external-clusterip: "true"
 
   # kube-proxy
   kube-proxy-replacement:  "probe"


### PR DESCRIPTION
* When a router sets node(s) as next-hops in a network, ClusterIP Services should be able to respond as usual
* https://github.com/cilium/cilium/issues/14581