### PR TITLE
Update Calico and Cilium CNI providers

### DIFF
--- a/resources/cilium/config.yaml
+++ b/resources/cilium/config.yaml
@@ -104,9 +104,6 @@ data:
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: default
 
-  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
-  wait-bpf-mount: "false"
-
   auto-direct-node-routes: "false"
 
   # enableXTSocketFallback enables the fallback compatibility solution

--- a/resources/cilium/daemonset.yaml
+++ b/resources/cilium/daemonset.yaml
@@ -64,13 +64,6 @@ spec:
         image: ${cilium_agent_image}
         command:
         - /init-container.sh
-        env:
-        - name: CILIUM_WAIT_BPF_MOUNT
-          valueFrom:
-            configMapKeyRef:
-              name: cilium
-              key: wait-bpf-mount
-              optional: true
         securityContext:
           capabilities:
             add:
@@ -79,7 +72,6 @@ spec:
         volumeMounts:
         - name: sys-fs-bpf
           mountPath: /sys/fs/bpf
-          mountPropagation: HostToContainer
         - name: var-run-cilium
           mountPath: /var/run/cilium
         # Required to mount cgroup filesystem from the host to cilium agent pod
@@ -162,6 +154,7 @@ spec:
           mountPath: /var/run/cilium
         - name: sys-fs-bpf
           mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
         # Configuration
         - name: config
           mountPath: /tmp/cilium/config-map

--- a/variables.tf
+++ b/variables.tf
@@ -58,10 +58,10 @@ variable "container_images" {
   description = "Container images to use"
 
   default = {
-    calico                  = "quay.io/calico/node:v3.20.0"
-    calico_cni              = "quay.io/calico/cni:v3.20.0"
-    cilium_agent            = "quay.io/cilium/cilium:v1.10.3"
-    cilium_operator         = "quay.io/cilium/operator-generic:v1.10.3"
+    calico                  = "quay.io/calico/node:v3.20.1"
+    calico_cni              = "quay.io/calico/cni:v3.20.1"
+    cilium_agent            = "quay.io/cilium/cilium:v1.10.4"
+    cilium_operator         = "quay.io/cilium/operator-generic:v1.10.4"
     coredns                 = "k8s.gcr.io/coredns/coredns:v1.8.4"
     flannel                 = "quay.io/coreos/flannel:v0.13.0"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.2"


### PR DESCRIPTION
* Update Calico from v3.20.0 to v3.20.1
* Update Cilium from v1.10.3 to v1.10.4
* Remove Cilium wait for BGF mount https://github.com/cilium/cilium/pull/16656