### PR TITLE
Enable Kubernetes aggregation by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -87,8 +87,8 @@ variable "enable_reporting" {
 
 variable "enable_aggregation" {
   type        = bool
-  description = "Enable the Kubernetes Aggregation Layer (defaults to false, recommended)"
-  default     = false
+  description = "Enable the Kubernetes Aggregation Layer (defaults to true)"
+  default     = true
 }
 
 variable "daemonset_tolerations" {


### PR DESCRIPTION
* Change `enable_aggregation` default from false to true
* These days, Kubernetes control plane components emit annoying messages related to assumptions baked into the Kubernetes API Aggregation Layer if you don't enable it. Further, the conformance tests force you to remember to enable it if you care about passing those
* This change is motivated by eliminating annoyances, rather than any enthusiasm for Kubernetes' aggregation features (I'd personally recommend you avoid them like the plague)
* https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/