### PR TITLE
Update Calico from v3.20.1 to v3.20.2

### DIFF
--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -137,6 +137,9 @@ spec:
               value: "false"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            # Detect iptables legacy or nft
+            - name: FELIX_IPTABLESBACKEND
+              value: "Auto"
           securityContext:
             privileged: true
           resources:

--- a/variables.tf
+++ b/variables.tf
@@ -58,8 +58,8 @@ variable "container_images" {
   description = "Container images to use"
 
   default = {
-    calico                  = "quay.io/calico/node:v3.20.1"
-    calico_cni              = "quay.io/calico/cni:v3.20.1"
+    calico                  = "quay.io/calico/node:v3.20.2"
+    calico_cni              = "quay.io/calico/cni:v3.20.2"
     cilium_agent            = "quay.io/cilium/cilium:v1.10.4"
     cilium_operator         = "quay.io/cilium/operator-generic:v1.10.4"
     coredns                 = "k8s.gcr.io/coredns/coredns:v1.8.4"


### PR DESCRIPTION
* https://github.com/projectcalico/calico/releases/tag/v3.20.2
* Add support for iptables legacy vs nft detection