### PR TITLE
Update minimum Terraform provider versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,8 @@
 terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
-    random   = ">= 2.2, < 4"
-    template = ">= 2.1, < 4"
-    tls      = ">= 2.0, < 4"
+    random   = "~> 3.1"
+    template = "~> 2.2"
+    tls      = "~> 3.1"
   }
 }


### PR DESCRIPTION
* Update minimum required versions for `tls`, `template`, and `random`. Older versions have some differing behaviors
(e.g. `random` may be missing sensitive fields) and we'd prefer to shake loose any setups still using very old providers than continue allowing them
* Remove the upper bound version constraint since providers are more regularly updated these days and require less manual vetting to allow use