### PR TITLE
Normalize CA certs mounts in static Pods and kube-proxy

### DIFF
--- a/manifests.tf
+++ b/manifests.tf
@@ -13,7 +13,6 @@ locals {
         etcd_servers      = join(",", formatlist("https://%s:2379", var.etcd_servers))
         pod_cidr          = var.pod_cidr
         service_cidr      = var.service_cidr
-        trusted_certs_dir = var.trusted_certs_dir
         aggregation_flags = var.enable_aggregation ? indent(4, local.aggregation_flags) : ""
       }
     )
@@ -32,7 +31,6 @@ locals {
         pod_cidr               = var.pod_cidr
         cluster_domain_suffix  = var.cluster_domain_suffix
         cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
-        trusted_certs_dir      = var.trusted_certs_dir
         server                 = format("https://%s:%s", var.api_servers[0], var.external_apiserver_port)
         daemonset_tolerations  = var.daemonset_tolerations
         token_id               = random_password.bootstrap-token-id.result

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -71,8 +71,11 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
-        - name: ssl-certs-host
+        - name: etc-ssl
           mountPath: /etc/ssl/certs
+          readOnly: true
+        - name: etc-pki
+          mountPath: /etc/pki
           readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
@@ -83,9 +86,12 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
-      - name: ssl-certs-host
+      - name: etc-ssl
         hostPath:
-          path: ${trusted_certs_dir}
+          path: /etc/ssl/certs
+      - name: etc-pki
+        hostPath:
+          path: /etc/pki
       # Access iptables concurrently
       - name: xtables-lock
         hostPath:

--- a/resources/static-manifests/kube-apiserver.yaml
+++ b/resources/static-manifests/kube-apiserver.yaml
@@ -53,13 +53,19 @@ spec:
     - name: secrets
       mountPath: /etc/kubernetes/pki
       readOnly: true
-    - name: ssl-certs-host
+    - name: etc-ssl
       mountPath: /etc/ssl/certs
+      readOnly: true
+    - name: etc-pki
+      mountPath: /etc/pki
       readOnly: true
   volumes:
   - name: secrets
     hostPath:
       path: /etc/kubernetes/pki
-  - name: ssl-certs-host
+  - name: etc-ssl
     hostPath:
-      path: ${trusted_certs_dir}
+      path: /etc/ssl/certs
+  - name: etc-pki
+    hostPath:
+      path: /etc/pki

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -52,8 +52,11 @@ spec:
     - name: secrets
       mountPath: /etc/kubernetes/pki
       readOnly: true
-    - name: ssl-host
+    - name: etc-ssl
       mountPath: /etc/ssl/certs
+      readOnly: true
+    - name: etc-pki
+      mountPath: /etc/pki
       readOnly: true
     - name: flex
       mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
@@ -61,11 +64,13 @@ spec:
   - name: secrets
     hostPath:
       path: /etc/kubernetes/pki
-  - name: ssl-host
+  - name: etc-ssl
     hostPath:
-      path: ${trusted_certs_dir}
+      path: /etc/ssl/certs
+  - name: etc-pki
+    hostPath:
+      path: /etc/pki
   - name: flex
     hostPath:
       type: DirectoryOrCreate
       path: /var/lib/kubelet/volumeplugins
-

--- a/resources/static-manifests/kube-scheduler.yaml
+++ b/resources/static-manifests/kube-scheduler.yaml
@@ -23,7 +23,6 @@ spec:
     - --authorization-kubeconfig=/etc/kubernetes/pki/scheduler.conf
     - --kubeconfig=/etc/kubernetes/pki/scheduler.conf
     - --leader-elect=true
-    - --port=0
     livenessProbe:
       httpGet:
         scheme: HTTPS

--- a/variables.tf
+++ b/variables.tf
@@ -74,13 +74,6 @@ variable "container_images" {
   }
 }
 
-
-variable "trusted_certs_dir" {
-  type        = string
-  description = "Path to the directory on cluster nodes where trust TLS certs are kept"
-  default     = "/usr/share/ca-certificates"
-}
-
 variable "enable_reporting" {
   type        = bool
   description = "Enable usage or analytics reporting to upstream component owners (Tigera: Calico)"


### PR DESCRIPTION
* Mount both /etc/ssl/certs and /etc/pki into control plane static pods and kube-proxy, rather than choosing one based a variable (set based on Flatcar Linux or Fedora CoreOS)
* Remove `trusted_certs_dir` variable
* Remove deprecated `--port` from `kube-scheduler` static Pod