### PR TITLE
Update cilium DaemonSet name and label to align with upstream

### DIFF
--- a/resources/cilium/daemonset.yaml
+++ b/resources/cilium/daemonset.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: cilium-agent
+  name: cilium
   namespace: kube-system
   labels:
-    k8s-app: cilium-agent
+    k8s-app: cilium
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This small change aligns the DaemonSet name and label to match a deployment made with the official CLI. This enables the use of the [status command](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#validate-the-installation), [connectivity tests](https://docs.cilium.io/en/stable/operations/troubleshooting/#connectivity-problems), etc. that expect the DaemonSet to have a specific name.