### PR TITLE
Remove unneeded use of `key_algorithm` and `ca_key_algorithm`

### DIFF
--- a/tls-aggregation.tf
+++ b/tls-aggregation.tf
@@ -20,7 +20,6 @@ resource "tls_private_key" "aggregation-ca" {
 resource "tls_self_signed_cert" "aggregation-ca" {
   count = var.enable_aggregation ? 1 : 0
 
-  key_algorithm   = tls_private_key.aggregation-ca[0].algorithm
   private_key_pem = tls_private_key.aggregation-ca[0].private_key_pem
 
   subject {
@@ -50,7 +49,6 @@ resource "tls_private_key" "aggregation-client" {
 resource "tls_cert_request" "aggregation-client" {
   count = var.enable_aggregation ? 1 : 0
 
-  key_algorithm   = tls_private_key.aggregation-client[0].algorithm
   private_key_pem = tls_private_key.aggregation-client[0].private_key_pem
 
   subject {
@@ -63,7 +61,6 @@ resource "tls_locally_signed_cert" "aggregation-client" {
 
   cert_request_pem = tls_cert_request.aggregation-client[0].cert_request_pem
 
-  ca_key_algorithm   = tls_self_signed_cert.aggregation-ca[0].key_algorithm
   ca_private_key_pem = tls_private_key.aggregation-ca[0].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.aggregation-ca[0].cert_pem
 

--- a/tls-etcd.tf
+++ b/tls-etcd.tf
@@ -21,7 +21,6 @@ resource "tls_private_key" "etcd-ca" {
 }
 
 resource "tls_self_signed_cert" "etcd-ca" {
-  key_algorithm   = tls_private_key.etcd-ca.algorithm
   private_key_pem = tls_private_key.etcd-ca.private_key_pem
 
   subject {
@@ -47,7 +46,6 @@ resource "tls_private_key" "client" {
 }
 
 resource "tls_cert_request" "client" {
-  key_algorithm   = tls_private_key.client.algorithm
   private_key_pem = tls_private_key.client.private_key_pem
 
   subject {
@@ -65,7 +63,6 @@ resource "tls_cert_request" "client" {
 resource "tls_locally_signed_cert" "client" {
   cert_request_pem = tls_cert_request.client.cert_request_pem
 
-  ca_key_algorithm   = tls_self_signed_cert.etcd-ca.key_algorithm
   ca_private_key_pem = tls_private_key.etcd-ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.etcd-ca.cert_pem
 
@@ -87,7 +84,6 @@ resource "tls_private_key" "server" {
 }
 
 resource "tls_cert_request" "server" {
-  key_algorithm   = tls_private_key.server.algorithm
   private_key_pem = tls_private_key.server.private_key_pem
 
   subject {
@@ -105,7 +101,6 @@ resource "tls_cert_request" "server" {
 resource "tls_locally_signed_cert" "server" {
   cert_request_pem = tls_cert_request.server.cert_request_pem
 
-  ca_key_algorithm   = tls_self_signed_cert.etcd-ca.key_algorithm
   ca_private_key_pem = tls_private_key.etcd-ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.etcd-ca.cert_pem
 
@@ -127,7 +122,6 @@ resource "tls_private_key" "peer" {
 }
 
 resource "tls_cert_request" "peer" {
-  key_algorithm   = tls_private_key.peer.algorithm
   private_key_pem = tls_private_key.peer.private_key_pem
 
   subject {
@@ -141,7 +135,6 @@ resource "tls_cert_request" "peer" {
 resource "tls_locally_signed_cert" "peer" {
   cert_request_pem = tls_cert_request.peer.cert_request_pem
 
-  ca_key_algorithm   = tls_self_signed_cert.etcd-ca.key_algorithm
   ca_private_key_pem = tls_private_key.etcd-ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.etcd-ca.cert_pem
 

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -18,7 +18,6 @@ resource "tls_private_key" "kube-ca" {
 }
 
 resource "tls_self_signed_cert" "kube-ca" {
-  key_algorithm   = tls_private_key.kube-ca.algorithm
   private_key_pem = tls_private_key.kube-ca.private_key_pem
 
   subject {
@@ -44,7 +43,6 @@ resource "tls_private_key" "apiserver" {
 }
 
 resource "tls_cert_request" "apiserver" {
-  key_algorithm   = tls_private_key.apiserver.algorithm
   private_key_pem = tls_private_key.apiserver.private_key_pem
 
   subject {
@@ -68,7 +66,6 @@ resource "tls_cert_request" "apiserver" {
 resource "tls_locally_signed_cert" "apiserver" {
   cert_request_pem = tls_cert_request.apiserver.cert_request_pem
 
-  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
   ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
 
@@ -90,7 +87,6 @@ resource "tls_private_key" "controller-manager" {
 }
 
 resource "tls_cert_request" "controller-manager" {
-  key_algorithm   = tls_private_key.controller-manager.algorithm
   private_key_pem = tls_private_key.controller-manager.private_key_pem
 
   subject {
@@ -101,7 +97,6 @@ resource "tls_cert_request" "controller-manager" {
 resource "tls_locally_signed_cert" "controller-manager" {
   cert_request_pem = tls_cert_request.controller-manager.cert_request_pem
 
-  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
   ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
 
@@ -122,7 +117,6 @@ resource "tls_private_key" "scheduler" {
 }
 
 resource "tls_cert_request" "scheduler" {
-  key_algorithm   = tls_private_key.scheduler.algorithm
   private_key_pem = tls_private_key.scheduler.private_key_pem
 
   subject {
@@ -133,7 +127,6 @@ resource "tls_cert_request" "scheduler" {
 resource "tls_locally_signed_cert" "scheduler" {
   cert_request_pem = tls_cert_request.scheduler.cert_request_pem
 
-  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
   ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
 
@@ -154,7 +147,6 @@ resource "tls_private_key" "admin" {
 }
 
 resource "tls_cert_request" "admin" {
-  key_algorithm   = tls_private_key.admin.algorithm
   private_key_pem = tls_private_key.admin.private_key_pem
 
   subject {
@@ -166,7 +158,6 @@ resource "tls_cert_request" "admin" {
 resource "tls_locally_signed_cert" "admin" {
   cert_request_pem = tls_cert_request.admin.cert_request_pem
 
-  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
   ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,6 +4,6 @@ terraform {
   required_version = ">= 0.13.0, < 2.0.0"
   required_providers {
     random = "~> 3.1"
-    tls    = "~> 3.1"
+    tls    = "~> 3.2"
   }
 }


### PR DESCRIPTION
* Remove uses of `key_algorithm` on `tls_self_signed_cert` and `tls_cert_request` resources. The field is deprecated and inferred from the `private_key_pem`
* Remove uses of `ca_key_algorithm` on `tls_locally_signed_cert` resources. The field is deprecated and inferred from the `ca_private_key_pem`
* Require at least hashicorp/tls provider v3.2

Rel: https://github.com/hashicorp/terraform-provider-tls/blob/main/CHANGELOG.md#320-april-04-2022