### PR TITLE
Upgrade CoreDNS from v1.8.5 to v1.9.3

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "container_images" {
     calico_cni              = "quay.io/calico/cni:v3.23.3"
     cilium_agent            = "quay.io/cilium/cilium:v1.12.0"
     cilium_operator         = "quay.io/cilium/operator-generic:v1.12.0"
-    coredns                 = "k8s.gcr.io/coredns/coredns:v1.8.6"
+    coredns                 = "registry.k8s.io/coredns/coredns:v1.9.3"
     flannel                 = "quay.io/coreos/flannel:v0.15.1"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.2"
     kube_apiserver          = "k8s.gcr.io/kube-apiserver:v1.24.3"


### PR DESCRIPTION
* https://coredns.io/2022/05/27/coredns-1.9.3-release/
* https://coredns.io/2022/05/13/coredns-1.9.2-release/
* https://coredns.io/2022/03/09/coredns-1.9.1-release/
* https://coredns.io/2022/02/01/coredns-1.9.0-release/
* https://coredns.io/2021/12/09/coredns-1.8.7-release/
* https://coredns.io/2021/10/07/coredns-1.8.6-release/