### PR TITLE
Switch upstream Kubernetes registry from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -67,10 +67,10 @@ variable "container_images" {
     coredns                 = "registry.k8s.io/coredns/coredns:v1.9.3"
     flannel                 = "quay.io/coreos/flannel:v0.15.1"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.2"
-    kube_apiserver          = "k8s.gcr.io/kube-apiserver:v1.24.3"
-    kube_controller_manager = "k8s.gcr.io/kube-controller-manager:v1.24.3"
-    kube_scheduler          = "k8s.gcr.io/kube-scheduler:v1.24.3"
-    kube_proxy              = "k8s.gcr.io/kube-proxy:v1.24.3"
+    kube_apiserver          = "registry.k8s.io/kube-apiserver:v1.24.3"
+    kube_controller_manager = "registry.k8s.io/kube-controller-manager:v1.24.3"
+    kube_scheduler          = "registry.k8s.io/kube-scheduler:v1.24.3"
+    kube_proxy              = "registry.k8s.io/kube-proxy:v1.24.3"
   }
 }
 


### PR DESCRIPTION
* Upstream would like to switch to registry.k8s.io to reduce costs

Rel: https://groups.google.com/g/kubernetes-sig-testing/c/U7b_im9vRrM