### PR TITLE
Allow Kubelet kubeconfig to drain nodes

### DIFF
--- a/resources/manifests/kubelet-delete-cluster-role.yaml
+++ b/resources/manifests/kubelet-delete-cluster-role.yaml
@@ -8,3 +8,16 @@ rules:
       - nodes
     verbs:
       - delete
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+  - apiGroups: [""]
+    resources:
+      - pods/eviction
+    verbs:
+      - create


### PR DESCRIPTION
* Allow the Kubelet kubeconfig to get/list workloads and evict pods to perform drain operations, via the kubelet-delete ClusterRole bound to the system:nodes group
* Previously, the ClusterRole only allowed node deletion