### PR TITLE
Update Cilium from v1.12.5 to v1.12.6

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -62,8 +62,8 @@ variable "container_images" {
   default = {
     calico                  = "quay.io/calico/node:v3.25.0"
     calico_cni              = "quay.io/calico/cni:v3.25.0"
-    cilium_agent            = "quay.io/cilium/cilium:v1.12.5"
-    cilium_operator         = "quay.io/cilium/operator-generic:v1.12.5"
+    cilium_agent            = "quay.io/cilium/cilium:v1.12.6"
+    cilium_operator         = "quay.io/cilium/operator-generic:v1.12.6"
     coredns                 = "registry.k8s.io/coredns/coredns:v1.9.4"
     flannel                 = "docker.io/flannelcni/flannel:v0.20.2"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.2"


### PR DESCRIPTION
* https://github.com/cilium/cilium/releases/tag/v1.12.6