### PR TITLE
Update Cilium from v1.13.1 to v1.13.2

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -62,8 +62,8 @@ variable "container_images" {
   default = {
     calico                  = "quay.io/calico/node:v3.25.1"
     calico_cni              = "quay.io/calico/cni:v3.25.1"
-    cilium_agent            = "quay.io/cilium/cilium:v1.13.1"
-    cilium_operator         = "quay.io/cilium/operator-generic:v1.13.0"
+    cilium_agent            = "quay.io/cilium/cilium:v1.13.2"
+    cilium_operator         = "quay.io/cilium/operator-generic:v1.13.2"
     coredns                 = "registry.k8s.io/coredns/coredns:v1.9.4"
     flannel                 = "docker.io/flannel/flannel:v0.21.2"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.2"


### PR DESCRIPTION
* https://github.com/cilium/cilium/releases/tag/v1.13.2