### PR TITLE
Update cilium masquerade flag

### DIFF
--- a/resources/cilium/config.yaml
+++ b/resources/cilium/config.yaml
@@ -120,7 +120,9 @@ data:
   install-iptables-rules: "true"
 
   # masquerade traffic leaving the node destined for outside
-  masquerade: "true"
+  enable-ipv4-masquerade: "true"
+  enable-ipv6-masquerade: "false"
+
   # bpfMasquerade enables masquerading with BPF instead of iptables
   enable-bpf-masquerade: "true"
 


### PR DESCRIPTION
https://github.com/cilium/cilium/commit/14ced84f7ef847350de8606b9e3159151a365531 introduced `enable-ipv6-masquerade` and `enable-ipv4-masquerade`. This updates the ConfigMap of cilium to align with the expected flag.

enable-ipv4-masquerade is enabled and enable-ipv6-masquerade is disabled.