### PR TITLE
Update Calico from v3.25.1 to v3.26.1

### DIFF
--- a/resources/calico/cluster-role-binding.yaml
+++ b/resources/calico/cluster-role-binding.yaml
@@ -10,3 +10,18 @@ subjects:
 - kind: ServiceAccount
   name: calico-node
   namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-cni-plugin
+subjects:
+- kind: ServiceAccount
+  name: calico-cni-plugin
+  namespace: kube-system

--- a/resources/calico/cluster-role.yaml
+++ b/resources/calico/cluster-role.yaml
@@ -62,7 +62,7 @@ rules:
     resources:
       - serviceaccounts/token
     resourceNames:
-      - calico-node
+      - calico-cni-plugin
     verbs:
       - create
   # Calico monitors its CRDs
@@ -71,6 +71,7 @@ rules:
       - globalfelixconfigs
       - felixconfigurations
       - bgppeers
+      - bgpfilters
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
@@ -143,3 +144,40 @@ rules:
       - configmaps
     verbs:
       - get
+
+---
+
+# Starting in Calico v3.26, calico-cni-plugin is separate
+# https://github.com/projectcalico/calico/pull/7106
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: calico-cni-plugin
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      - clusterinformations
+      - ippools
+      - ipreservations
+      - ipamconfigs
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete

--- a/resources/calico/crd-bgpfilters.yaml
+++ b/resources/calico/crd-bgpfilters.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: bgpfilters.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPFilter
+    listKind: BGPFilterList
+    plural: bgpfilters
+    singular: bgpfilter
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BGPFilterSpec contains the IPv4 and IPv6 filter rules of the BGP Filter.
+              properties:
+                exportV4:
+                  description: The ordered set of IPv4 BGPFilter rules acting on exporting routes to a peer.
+                  items:
+                    description: BGPFilterRuleV4 defines a BGP filter rule consisting a single IPv4 CIDR block and a filter action for this CIDR.
+                    properties:
+                      action:
+                        type: string
+                      cidr:
+                        type: string
+                      matchOperator:
+                        type: string
+                    required:
+                      - action
+                      - cidr
+                      - matchOperator
+                    type: object
+                  type: array
+                exportV6:
+                  description: The ordered set of IPv6 BGPFilter rules acting on exporting routes to a peer.
+                  items:
+                    description: BGPFilterRuleV6 defines a BGP filter rule consisting a single IPv6 CIDR block and a filter action for this CIDR.
+                    properties:
+                      action:
+                        type: string
+                      cidr:
+                        type: string
+                      matchOperator:
+                        type: string
+                    required:
+                      - action
+                      - cidr
+                      - matchOperator
+                    type: object
+                  type: array
+                importV4:
+                  description: The ordered set of IPv4 BGPFilter rules acting on importing routes from a peer.
+                  items:
+                    description: BGPFilterRuleV4 defines a BGP filter rule consisting a single IPv4 CIDR block and a filter action for this CIDR.
+                    properties:
+                      action:
+                        type: string
+                      cidr:
+                        type: string
+                      matchOperator:
+                        type: string
+                    required:
+                      - action
+                      - cidr
+                      - matchOperator
+                    type: object
+                  type: array
+                importV6:
+                  description: The ordered set of IPv6 BGPFilter rules acting on importing routes from a peer.
+                  items:
+                    description: BGPFilterRuleV6 defines a BGP filter rule consisting a single IPv6 CIDR block and a filter action for this CIDR.
+                    properties:
+                      action:
+                        type: string
+                      cidr:
+                        type: string
+                      matchOperator:
+                        type: string
+                    required:
+                      - action
+                      - cidr
+                      - matchOperator
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/resources/calico/crd-bgppeers.yaml
+++ b/resources/calico/crd-bgppeers.yaml
@@ -31,6 +31,11 @@ spec:
                   description: The AS Number of the peer.
                   format: int32
                   type: integer
+                filters:
+                  description: The ordered set of BGPFilters applied on this BGP peer.
+                  items:
+                    type: string
+                  type: array
                 keepOriginalNextHop:
                   description: Option to keep the original nexthop field when routes are sent to a BGP Peer. Setting "true" configures the selected BGP Peers node to use the "next hop keep;" instead of "next hop self;"(default) in the specific branch of the Node on "bird.cfg".
                   type: boolean

--- a/resources/calico/crd-felixconfigurations.yaml
+++ b/resources/calico/crd-felixconfigurations.yaml
@@ -44,6 +44,11 @@ spec:
                 bpfConnectTimeLoadBalancingEnabled:
                   description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode, controls whether Felix installs the connection-time load balancer.  The connect-time load balancer is required for the host to be able to reach Kubernetes services and it improves the performance of pod-to-service connections.  The only reason to disable it is for debugging purposes.  [Default: true]'
                   type: boolean
+                bpfDSROptoutCIDRs:
+                  description: BPFDSROptoutCIDRs is a list of CIDRs which are excluded from DSR. That is, clients in those CIDRs will accesses nodeports as if BPFExternalServiceMode was set to Tunnel.
+                  items:
+                    type: string
+                  type: array
                 bpfDataIfacePattern:
                   description: BPFDataIfacePattern is a regular expression that controls which interfaces Felix should attach BPF programs to in order to catch traffic to/from the network.  This needs to match the interfaces that Calico workload traffic flows over as well as any interfaces that handle incoming traffic to nodeports and services from outside the cluster.  It should not match the workload interfaces (usually named cali...).
                   type: string
@@ -54,7 +59,7 @@ spec:
                   description: 'BPFEnabled, if enabled Felix will use the BPF dataplane. [Default: false]'
                   type: boolean
                 bpfEnforceRPF:
-                  description: 'BPFEnforceRPF enforce strict RPF on all host interfaces with BPF programs regardless of what is the per-interfaces or global setting. Possible values are Disabled, Strict or Loose. [Default: Strict]'
+                  description: 'BPFEnforceRPF enforce strict RPF on all host interfaces with BPF programs regardless of what is the per-interfaces or global setting. Possible values are Disabled, Strict or Loose. [Default: Loose]'
                   type: string
                 bpfExtToServiceConnmark:
                   description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit mark that is set on connections from an external client to a local service. This mark allows us to control how packets of that connection are routed within the host and how is routing interpreted by RPF check. [Default: 0]'
@@ -204,7 +209,7 @@ spec:
                 healthPort:
                   type: integer
                 healthTimeoutOverrides:
-                  description: HealthTimeoutOverrides allows the internal watchdog timeouts of individual subcomponents to be overriden.  This is useful for working around "false positive" liveness timeouts that can occur in particularly stressful workloads or if CPU is constrained.  For a list of active subcomponents, see Felix's logs.
+                  description: HealthTimeoutOverrides allows the internal watchdog timeouts of individual subcomponents to be overridden.  This is useful for working around "false positive" liveness timeouts that can occur in particularly stressful workloads or if CPU is constrained.  For a list of active subcomponents, see Felix's logs.
                   items:
                     properties:
                       name:
@@ -238,6 +243,9 @@ spec:
                   description: IptablesBackend specifies which backend of iptables will be used. The default is Auto.
                   type: string
                 iptablesFilterAllowAction:
+                  type: string
+                iptablesFilterDenyAction:
+                  description: IptablesFilterDenyAction controls what happens to traffic that is denied by network policy. By default Calico blocks traffic with an iptables "DROP" action. If you want to use "REJECT" action instead you can configure it in here.
                   type: string
                 iptablesLockFilePath:
                   description: 'IptablesLockFilePath is the location of the iptables lock file. You may need to change this if the lock file is not in its standard location (for example if you have mapped it into Felix''s container at a different path). [Default: /run/xtables.lock]'

--- a/resources/calico/service-account.yaml
+++ b/resources/calico/service-account.yaml
@@ -3,3 +3,11 @@ kind: ServiceAccount
 metadata:
   name: calico-node
   namespace: kube-system
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system

--- a/variables.tf
+++ b/variables.tf
@@ -60,8 +60,8 @@ variable "container_images" {
   description = "Container images to use"
 
   default = {
-    calico                  = "quay.io/calico/node:v3.25.1"
-    calico_cni              = "quay.io/calico/cni:v3.25.1"
+    calico                  = "quay.io/calico/node:v3.26.1"
+    calico_cni              = "quay.io/calico/cni:v3.26.1"
     cilium_agent            = "quay.io/cilium/cilium:v1.13.4"
     cilium_operator         = "quay.io/cilium/operator-generic:v1.13.4"
     coredns                 = "registry.k8s.io/coredns/coredns:v1.9.4"


### PR DESCRIPTION
* Calico made some changes related to how the install-cni init container runs, RBAC, and adds a new CRD bgpfilters
* https://github.com/projectcalico/calico/releases/tag/v3.26.1

Rel: https://github.com/projectcalico/calico/pull/7106