### PR TITLE
Fix Cilium kube-proxy-replacement mode to true

### DIFF
--- a/resources/cilium/config.yaml
+++ b/resources/cilium/config.yaml
@@ -128,7 +128,7 @@ data:
   enable-bpf-masquerade: "true"
 
   # kube-proxy
-  kube-proxy-replacement:  "false"
+  kube-proxy-replacement:  "true"
   kube-proxy-replacement-healthz-bind-address: ""
   enable-session-affinity: "true"
 


### PR DESCRIPTION
* In Cilium v1.14, kube-proxy-replacement mode again changed its valid values, this time from partial to true/false. The value should be true for Cilium to support HostPort features as expected

```
cilium status --verbose
Services:
  - ClusterIP:      Enabled
  - NodePort:       Enabled (Range: 30000-32767)
  - LoadBalancer:   Enabled
  - externalIPs:    Enabled
  - HostPort:       Enabled
```

Regressed in https://github.com/poseidon/terraform-render-bootstrap/pull/360