### PR TITLE
Bump Kubernetes images from v1.28.1 to v1.28.2

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -67,10 +67,10 @@ variable "container_images" {
     coredns                 = "registry.k8s.io/coredns/coredns:v1.9.4"
     flannel                 = "docker.io/flannel/flannel:v0.22.2"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.2"
-    kube_apiserver          = "registry.k8s.io/kube-apiserver:v1.28.1"
-    kube_controller_manager = "registry.k8s.io/kube-controller-manager:v1.28.1"
-    kube_scheduler          = "registry.k8s.io/kube-scheduler:v1.28.1"
-    kube_proxy              = "registry.k8s.io/kube-proxy:v1.28.1"
+    kube_apiserver          = "registry.k8s.io/kube-apiserver:v1.28.2"
+    kube_controller_manager = "registry.k8s.io/kube-controller-manager:v1.28.2"
+    kube_scheduler          = "registry.k8s.io/kube-scheduler:v1.28.2"
+    kube_proxy              = "registry.k8s.io/kube-proxy:v1.28.2"
   }
 }
 


### PR DESCRIPTION
* https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1282