### PR TITLE
Update Cilium and flannel container images

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -62,10 +62,10 @@ variable "container_images" {
   default = {
     calico                  = "quay.io/calico/node:v3.27.3"
     calico_cni              = "quay.io/calico/cni:v3.27.3"
-    cilium_agent            = "quay.io/cilium/cilium:v1.15.3"
-    cilium_operator         = "quay.io/cilium/operator-generic:v1.15.3"
+    cilium_agent            = "quay.io/cilium/cilium:v1.15.4"
+    cilium_operator         = "quay.io/cilium/operator-generic:v1.15.4"
     coredns                 = "registry.k8s.io/coredns/coredns:v1.9.4"
-    flannel                 = "docker.io/flannel/flannel:v0.24.4"
+    flannel                 = "docker.io/flannel/flannel:v0.25.1"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.4"
     kube_apiserver          = "registry.k8s.io/kube-apiserver:v1.30.0"
     kube_controller_manager = "registry.k8s.io/kube-controller-manager:v1.30.0"


### PR DESCRIPTION
* Update Cilium from v1.15.3 to v1.25.4
* Update flannel from v0.24.4 to v0.25.1