### PR TITLE
Extend components variable with flannel, calico, and cilium

### DIFF
--- a/conditional.tf
+++ b/conditional.tf
@@ -14,7 +14,7 @@ locals {
         daemonset_tolerations = var.daemonset_tolerations
       }
     )
-    if var.networking == "flannel"
+    if var.components.enable && var.components.flannel.enable && var.networking == "flannel"
   }
 
   # calico manifests map
@@ -37,7 +37,7 @@ locals {
         daemonset_tolerations           = var.daemonset_tolerations
       }
     )
-    if var.networking == "calico"
+    if var.components.enable && var.components.calico.enable && var.networking == "calico"
   }
 
   # cilium manifests map
@@ -53,7 +53,7 @@ locals {
         daemonset_tolerations = var.daemonset_tolerations
       }
     )
-    if var.networking == "cilium"
+    if var.components.enable && var.components.cilium.enable && var.networking == "cilium"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,8 +17,12 @@ variable "etcd_servers" {
 
 variable "networking" {
   type        = string
-  description = "Choice of networking provider (flannel or calico or cilium or none)"
+  description = "Choice of networking provider (flannel or calico or cilium)"
   default     = "flannel"
+  validation {
+    condition     = contains(["flannel", "calico", "cilium"], var.networking)
+    error_message = "networking can be flannel, calico, or cilium."
+  }
 }
 
 variable "network_mtu" {
@@ -124,11 +128,40 @@ variable "components" {
         enable = true
       }
     )
+    # CNI providers are enabled for pre-install by default, but only the
+    # provider matching var.networking is actually installed.
+    flannel = optional(
+      object({
+        enable = optional(bool, true)
+      }),
+      {
+        enable = true
+      }
+    )
+    calico = optional(
+      object({
+        enable = optional(bool, true)
+      }),
+      {
+        enable = true
+      }
+    )
+    cilium = optional(
+      object({
+        enable = optional(bool, true)
+      }),
+      {
+        enable = true
+      }
+    )
   })
   default = {
     enable     = true
     coredns    = null
     kube_proxy = null
+    flannel    = null
+    calico     = null
+    cilium     = null
   }
   # Set the variable value to the default value when the caller
   # sets it to null.


### PR DESCRIPTION
* By default the `networking` CNI provider is pre-installed, but the component variable provides an extensible mechanism to skip installing these components
* Validate that networking can only be set to one of flannel, calico, or cilium