### PR TITLE
Rename context in kubeconfig-admin

### DIFF
--- a/resources/kubeconfig-admin
+++ b/resources/kubeconfig-admin
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Config
 clusters:
-- name: ${name}-cluster
+- name: ${name}
   cluster:
     server: ${server}
     certificate-authority-data: ${ca_cert}
 users:
-- name: ${name}-user
+- name: ${name}
   user:
     client-certificate-data: ${kubelet_cert}
     client-key-data: ${kubelet_key}
-current-context: ${name}-context
+current-context: ${name}
 contexts:
-- name: ${name}-context
+- name: ${name}
   context:
-    cluster: ${name}-cluster
-    user: ${name}-user
+    cluster: ${name}
+    user: ${name}


### PR DESCRIPTION
* Use the cluster_name as the kubeconfig context, cluster, and user. Drop the trailing -context suffix