### PR TITLE
Update CoreDNS and Cilium components

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -64,9 +64,9 @@ variable "container_images" {
   default = {
     calico                  = "quay.io/calico/node:v3.27.3"
     calico_cni              = "quay.io/calico/cni:v3.27.3"
-    cilium_agent            = "quay.io/cilium/cilium:v1.15.7"
-    cilium_operator         = "quay.io/cilium/operator-generic:v1.15.7"
-    coredns                 = "registry.k8s.io/coredns/coredns:v1.11.1"
+    cilium_agent            = "quay.io/cilium/cilium:v1.16.0"
+    cilium_operator         = "quay.io/cilium/operator-generic:v1.16.0"
+    coredns                 = "registry.k8s.io/coredns/coredns:v1.11.3"
     flannel                 = "docker.io/flannel/flannel:v0.25.5"
     flannel_cni             = "quay.io/poseidon/flannel-cni:v0.4.4"
     kube_apiserver          = "registry.k8s.io/kube-apiserver:v1.30.3"


### PR DESCRIPTION
* Update CoreDNS from v1.11.1 to v1.11.3
* Update Cilium from v1.15.7 to v1.16.0