### PR TITLE
Change Cilium configuration to use kube-proxy replacement

### DIFF
--- a/manifests.tf
+++ b/manifests.tf
@@ -56,7 +56,7 @@ locals {
           pod_cidr              = var.pod_cidr
           daemonset_tolerations = var.daemonset_tolerations
         }
-      ) if var.components.enable && var.components.kube_proxy.enable
+      ) if var.components.enable && var.components.kube_proxy.enable && var.networking != "cilium"
     }
   )
 }

--- a/resources/cilium/config.yaml
+++ b/resources/cilium/config.yaml
@@ -127,8 +127,8 @@ data:
   enable-bpf-masquerade: "true"
 
   # kube-proxy
-  kube-proxy-replacement:  "false"
-  kube-proxy-replacement-healthz-bind-address: ""
+  kube-proxy-replacement:  "true"
+  kube-proxy-replacement-healthz-bind-address: ":10256"
   enable-session-affinity: "true"
 
   # ClusterIPs from host namespace


### PR DESCRIPTION
* Skip creating the kube-proxy DaemonSet when Cilium is chosen