### PR TITLE
Change the default Pod CIDR to 10.20.0.0/14

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "network_ip_autodetection_method" {
 variable "pod_cidr" {
   type        = string
   description = "CIDR IP range to assign Kubernetes pods"
-  default     = "10.2.0.0/16"
+  default     = "10.20.0.0/14"
 }
 
 variable "service_cidr" {


### PR DESCRIPTION
* Change the default Pod CIDR from 10.2.0.0/16 to 10.20.0.0/14 (10.20.0.0 - 10.23.255.255) to support 1024 nodes by default
* Most CNI providers divide the Pod CIDR so that each node has a /24 to allocate to local pods (256). The previous `10.2.0.0/16` default only fits 256 /24's so 256 nodes were supported without customizing the pod_cidr