### PR TITLE
Change flannel port from 4789 to 8472

### DIFF
--- a/resources/flannel/config.yaml
+++ b/resources/flannel/config.yaml
@@ -32,6 +32,6 @@ data:
       "Network": "${pod_cidr}",
       "Backend": {
         "Type": "vxlan",
-        "Port": 4789
+        "Port": 8472
       }
     }


### PR DESCRIPTION
* flannel and Cilium default to UDP 8472 for VXLAN traffic to avoid conflicts with other VXLAN usage (e.g. Open vSwith)
* Aligning flannel and Cilium to use the same vxlan port makes firewall rules or security policies simpler across clouds