### PR TITLE
Add service_account_issuer variable for kube-apiserver

### DIFF
--- a/manifests.tf
+++ b/manifests.tf
@@ -10,10 +10,12 @@ locals {
         kube_controller_manager_image = var.container_images["kube_controller_manager"]
         kube_scheduler_image          = var.container_images["kube_scheduler"]
 
-        etcd_servers      = join(",", formatlist("https://%s:2379", var.etcd_servers))
-        pod_cidr          = var.pod_cidr
-        service_cidr      = var.service_cidr
-        aggregation_flags = var.enable_aggregation ? indent(4, local.aggregation_flags) : ""
+        etcd_servers = join(",", formatlist("https://%s:2379", var.etcd_servers))
+        pod_cidr     = var.pod_cidr
+        service_cidr = var.service_cidr
+
+        service_account_issuer = var.service_account_issuer
+        aggregation_flags      = var.enable_aggregation ? indent(4, local.aggregation_flags) : ""
       }
     )
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -68,3 +68,9 @@ output "etcd_peer_key" {
   value     = tls_private_key.peer.private_key_pem
   sensitive = true
 }
+
+# Kubernetes TLS assets
+
+output "service_account_public_key" {
+  value = tls_private_key.service-account.public_key_pem
+}

--- a/resources/static-manifests/kube-apiserver.yaml
+++ b/resources/static-manifests/kube-apiserver.yaml
@@ -36,8 +36,8 @@ spec:
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname${aggregation_flags}
     - --runtime-config=admissionregistration.k8s.io/v1alpha1=true
     - --secure-port=6443
-    - --service-account-issuer=https://kubernetes.default.svc.cluster.local
-    - --service-account-jwks-uri=https://kubernetes.default.svc.cluster.local/openid/v1/jwks
+    - --service-account-issuer=${service_account_issuer}
+    - --service-account-jwks-uri=${service_account_issuer}/openid/v1/jwks
     - --service-account-key-file=/etc/kubernetes/pki/service-account.pub
     - --service-account-signing-key-file=/etc/kubernetes/pki/service-account.key
     - --service-cluster-ip-range=${service_cidr}

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,9 @@ variable "components" {
   # sets it to null.
   nullable = false
 }
+
+variable "service_account_issuer" {
+  type        = string
+  description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
+  default     = "https://kubernetes.default.svc.cluster.local"
+}


### PR DESCRIPTION
* Allow the service account token issuer to be adjusted or served from a public bucket or static cache
* Output the public key used to sign service account tokens so that it can be used to compute JWKS (JSON Web Key Sets) if desired

Docs: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery