### PR TITLE
Add cloud_provider variable to set kube-controller-manager flag

### DIFF
--- a/manifests.tf
+++ b/manifests.tf
@@ -15,6 +15,7 @@ locals {
         service_cidr = var.service_cidr
 
         service_account_issuer = var.service_account_issuer
+        cloud_provider_flag    = var.cloud_provider == null ? "" : indent(4, local.cloud_provider_flag)
         aggregation_flags      = var.enable_aggregation ? indent(4, local.aggregation_flags) : ""
       }
     )
@@ -64,6 +65,8 @@ locals {
 }
 
 locals {
+  cloud_provider_flag = "\n- --cloud-provider=${var.cloud_provider}"
+
   aggregation_flags = <<EOF
 
 - --proxy-client-cert-file=/etc/kubernetes/pki/aggregation-client.crt
@@ -74,4 +77,3 @@ locals {
 - --requestheader-username-headers=X-Remote-User
 EOF
 }
-

--- a/resources/static-manifests/kube-controller-manager.yaml
+++ b/resources/static-manifests/kube-controller-manager.yaml
@@ -22,7 +22,7 @@ spec:
     - --authentication-kubeconfig=/etc/kubernetes/pki/controller-manager.conf
     - --authorization-kubeconfig=/etc/kubernetes/pki/controller-manager.conf
     - --allocate-node-cidrs=true
-    - --client-ca-file=/etc/kubernetes/pki/ca.crt
+    - --client-ca-file=/etc/kubernetes/pki/ca.crt${cloud_provider_flag}
     - --cluster-cidr=${pod_cidr}
     - --cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt
     - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key

--- a/variables.tf
+++ b/variables.tf
@@ -138,3 +138,9 @@ variable "service_account_issuer" {
   description = "kube-apiserver service account token issuer (used as an identifier in 'iss' claims)"
   default     = "https://kubernetes.default.svc.cluster.local"
 }
+
+variable "cloud_provider" {
+  type        = string
+  description = "Cloud provider to set on Kubernetes components (e.g. external)"
+  default     = null
+}


### PR DESCRIPTION
* Add a cloud_provider variable so that external cloud controller managers can be used by setting the flag to "external". Note that nodes will be tainted until they are initialized by a cloud-specific controller manager (various implementations)