### PR TITLE
Ensure null cloud_provider doesn't template error

### DIFF
--- a/manifests.tf
+++ b/manifests.tf
@@ -65,7 +65,7 @@ locals {
 }
 
 locals {
-  cloud_provider_flag = "\n- --cloud-provider=${var.cloud_provider}"
+  cloud_provider_flag = "\n- --cloud-provider=${var.cloud_provider == null ? "" : var.cloud_provider}"
 
   aggregation_flags = <<EOF
 


### PR DESCRIPTION
* When the cloud_provider variable is null (the default), the cloud_provider_flag won't be used, but Terraform still evaluates the interpolation so we have to prevent it from erroring